### PR TITLE
Sign all URLs with the `ixlib` parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>com.imgix</groupId>
 	<artifactId>imgix</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.0</version>
 
 	<name>Imgix Java Client</name>
 	<description>Helpers for Imgix's API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 	<packaging>jar</packaging>
 	<url>https://github.com/imgix/imgix-java</url>
 	<scm>
-		<url>scm:git:ssh://github.com/imgix/imgix-java.git</url>
-		<developerConnection>scm:git:ssh://github.com/imgix/imgix-java.git</developerConnection>
+		<url>scm:git:ssh://github.com/imgix/imgix-java</url>
+		<developerConnection>scm:git:ssh://github.com/imgix/imgix-java</developerConnection>
 		<tag>imgix-1.0.0</tag>
 	</scm>
 	<licenses>


### PR DESCRIPTION
Per https://github.com/imgix/imgix-blueprint/issues/4, we should sign all generated URLs with the `ixlib` parameter for diagnostic purposes.

Please see https://github.com/imgix/imgix-rb/pull/10 for information on how this looks (in Ruby).
