### PR TITLE
Don't urlEncode "/" to "%2F" in imageKey.

### DIFF
--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -167,6 +167,7 @@ public class URLHelper {
 		try {
 		  result = URLEncoder.encode(s, "UTF-8")
 							 .replaceAll("\\+", "%20")
+							 .replaceAll("\\%2F", "/")
 							 .replaceAll("\\%21", "!")
 							 .replaceAll("\\%27", "'")
 							 .replaceAll("\\%28", "(")


### PR DESCRIPTION
Useful when you save image as and need to get the correct filename without full path containing the %2F in the in the filename.
