### PR TITLE
Fix for issue #14

### DIFF
--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -93,9 +93,8 @@ public class URLHelper {
 
 		String query = joinList(queryPairs, "&");
 
-		String decodedPath = URLHelper.decodeURIComponent(path.substring(1));
-		if (decodedPath.startsWith("http://") || decodedPath.startsWith("https://")) {
-			path = "/" + URLHelper.encodeURIComponent(decodedPath);
+		if (pathNeedsEncoding(path.substring(1))) {
+			path = "/" + URLHelper.encodeURIComponent(path.substring(1));
 		}
 
 		if (signKey != null && signKey.length() > 0) {
@@ -121,6 +120,15 @@ public class URLHelper {
 	}
 
 	///////////// Static
+
+	private static boolean pathNeedsEncoding(String path) {
+		// Incoming nested paths that are already encoded do not need encoding
+		if (path.startsWith("http%3A%2F%2F") || path.startsWith("https%3A%2F%2F")) {
+			return false;
+		}
+		// Assume nested paths that start with an unencoded scheme do need encoding
+		return (path.startsWith("http://") || path.startsWith("https://"));
+	}
 
 	private static String buildURL(String scheme, String host, String path, String query) {
 		// do not use URI to build URL since it will do auto-encoding which can break our previous signing

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -34,7 +34,7 @@ public class TestAll {
 	@Test
 	public void testHelperBuildAbsolutePath() {
 		URLHelper uh = new URLHelper("securejackangers.imgix.net", "/example/chester.png", "http");
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png");
+		assertEquals(uh.getURL(),"http://securejackangers.imgix.net/example/chester.png");
 	}
 
 	@Test
@@ -48,6 +48,20 @@ public class TestAll {
 		URLHelper uh = new URLHelper("securejackangers.imgix.net", "http://www.somedomain.com/example/chester.png", "http");
 		System.out.println(uh.getURL());
 		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester.png");
+	}
+
+	@Test
+	public void testHelperBuildNestedPathAlreadyEncoded() {
+		URLHelper uh = new URLHelper("securejackangers.imgix.net", "http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester.png", "http");
+		System.out.println(uh.getURL());
+		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester.png");
+	}
+
+	@Test
+	public void testHelperBuildNestedPathPartialEncoding() {
+		URLHelper uh = new URLHelper("securejackangers.imgix.net", "http://www.somedomain.com/example/chester%20resize.png", "http");
+		System.out.println(uh.getURL());
+		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester%2520resize.png");
 	}
 
 	@Test


### PR DESCRIPTION
Hey there,

This is a potential fix for the issue opened by @eboto last year.  The problem is that when you supply a "nested" path that is already partially encoded, that path gets incorrectly decoded and then re-encoded.  The re-encoding does not end up 'double-encoding' the partial encoding and thus breaks the origin url.  This PR should fix that by not decoding in the first place if the path does not require it.  I've also added tests, which should illustrate the original problem.

Thanks,
Baq