### PR TITLE
Use java.util.Base64 for base64 encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ version = '1.1.11'
 
 description = """Imgix Java Client"""
 
-sourceCompatibility = 1.5
-targetCompatibility = 1.5
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
 
 repositories {
     maven { url "http://repo.maven.apache.org/maven2" }

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 public class URLHelper {
 
@@ -65,7 +65,7 @@ public class URLHelper {
 
 	private String encodeBase64(String str) {
 		byte[] stringBytes = str.getBytes();
-		String b64EncodedString = DatatypeConverter.printBase64Binary(stringBytes);
+		String b64EncodedString = new String(Base64.getEncoder().encode(stringBytes));
 
 		b64EncodedString = b64EncodedString.replace("=", "");
 		b64EncodedString = b64EncodedString.replace('/', '_');


### PR DESCRIPTION
`javax.xml.bind.DatatypeConverter` has been removed in Java 10; use `java.util.Base64` instead. This should fix #27, too.