### PR TITLE
fix: deprecate domain sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ public class ImgixExample {
 
 Domain Sharded URLs
 -------------------
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release**<br>
+To find out more, see our [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding) explaining the decision to remove this feature.
 
 Domain sharding enables you to spread image requests across multiple domains.
 This allows you to bypass the requests-per-host limits of browsers. We

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -21,6 +21,11 @@ public class URLBuilder {
 
 	private int shardCycleNextIndex = 0;
 
+	/**
+	 * @deprecated  As of 1.2.0, domain sharding has been deprecated
+	 * 				and will be removed in the next major version.
+	 */
+	@Deprecated
 	public URLBuilder(String[] domains, boolean useHttps, String signKey, ShardStrategy shardStrategy, boolean signWithLibraryParameter) {
 
 		if (domains == null || domains.length == 0) {
@@ -38,10 +43,20 @@ public class URLBuilder {
 		this(new String[] {domain}, false);
 	}
 
+	/**
+	 * @deprecated  As of 1.2.0, domain sharding has been deprecated
+	 * 				and will be removed in the next major version.
+	 */
+	@Deprecated
 	public URLBuilder(String[] domain) {
 		this(domain, false);
 	}
 
+	/**
+	 * @deprecated  As of 1.2.0, domain sharding has been deprecated
+	 * 				and will be removed in the next major version.
+	 */
+	@Deprecated
 	public URLBuilder(String[] domain, boolean useHttps) {
 		this(domain, useHttps, "");
 	}
@@ -50,6 +65,11 @@ public class URLBuilder {
 		this(new String[] {domain}, useHttps, "");
 	}
 
+	/**
+	 * @deprecated  As of 1.2.0, domain sharding has been deprecated
+	 * 				and will be removed in the next major version.
+	 */
+	@Deprecated
 	public URLBuilder(String[] domain, boolean useHttps, String signKey) {
 		this(domain, useHttps, signKey, ShardStrategy.CRC, true);
 	}
@@ -62,6 +82,11 @@ public class URLBuilder {
 		this(new String[] {domain}, useHttps, signKey, shardStrategy, true);
 	}
 
+	/**
+	 * @deprecated  As of 1.2.0, domain sharding has been deprecated
+	 * 				and will be removed in the next major version.
+	 */
+	@Deprecated
 	public void setShardStratgy(ShardStrategy strat) {
 		shardStrategy = strat;
 	}

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -6,11 +6,13 @@ import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.rules.ExpectedException;
+
 import static org.junit.Assert.*;
 
 import com.imgix.URLBuilder;
 import com.imgix.URLHelper;
 
+import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
@@ -203,7 +205,6 @@ public class TestAll {
 		}
 	}
 
-
 	@Test
 	public void testExtractDomain() {
 		String url = "http://jackangers.imgix.net/chester.png";
@@ -218,6 +219,81 @@ public class TestAll {
 		assertEquals(URLHelper.encodeURIComponent(url), encodedUrl);
 		assertEquals(URLHelper.decodeURIComponent(encodedUrl), url);
 		assertEquals(URLHelper.encodeURIComponent(URLHelper.decodeURIComponent(encodedUrl)), encodedUrl);
+	}
+
+	@Test
+	public void testDomainShardingConstructorDeprecated1() {
+		Class[] classes = new Class[]{
+				String[].class, boolean.class, String.class,
+				URLBuilder.ShardStrategy.class, boolean.class
+		};
+		assertTrue(hasDeprecationAnnotationConstructor(classes));
+	}
+
+	@Test
+	public void testDomainShardingConstructorDeprecated2() {
+		Class[] classes = new Class[]{
+				String[].class
+		};
+		assertTrue(hasDeprecationAnnotationConstructor(classes));
+	}
+
+	@Test
+	public void testDomainShardingConstructorDeprecated3() {
+		Class[] classes = new Class[]{
+				String[].class, boolean.class
+		};
+		assertTrue(hasDeprecationAnnotationConstructor(classes));
+	}
+
+	@Test
+	public void testDomainShardingConstructorDeprecated4() {
+		Class[] classes = new Class[]{
+				String[].class, boolean.class, String.class
+		};
+		assertTrue(hasDeprecationAnnotationConstructor(classes));
+	}
+
+	@Test
+	public void testSetShardStrategyDeprecated() {
+		assertTrue(hasDeprecationAnnotationMethod("setShardStratgy", URLBuilder.ShardStrategy.class));
+	}
+
+	private boolean hasDeprecationAnnotationConstructor(Class[] classes) {
+		Annotation[] annotations = new Annotation[0];
+
+		try {
+			annotations = URLBuilder.class.getConstructor(classes).getAnnotations();
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+
+		for (Annotation annotation : annotations){
+			if(annotation.annotationType().equals(Deprecated.class)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean hasDeprecationAnnotationMethod(String name, Class type) {
+		Annotation[] annotations = new Annotation[0];
+
+		try {
+			annotations = URLBuilder.class.getDeclaredMethod(name,type).getAnnotations();
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+
+		for (Annotation annotation : annotations){
+			if(annotation.annotationType().equals(Deprecated.class)) {
+				return true;
+			}
+		}
+
+		return false;
+
 	}
 
 	private static String extractDomain(String url) {

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -1,12 +1,10 @@
 package com.imgix.test;
 
 import org.junit.Test;
-
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.rules.ExpectedException;
-
 import static org.junit.Assert.*;
 
 import com.imgix.URLBuilder;
@@ -223,7 +221,7 @@ public class TestAll {
 
 	@Test
 	public void testDomainShardingConstructorDeprecated1() {
-		Class[] classes = new Class[]{
+		Class[] classes = new Class[] {
 				String[].class, boolean.class, String.class,
 				URLBuilder.ShardStrategy.class, boolean.class
 		};
@@ -232,7 +230,7 @@ public class TestAll {
 
 	@Test
 	public void testDomainShardingConstructorDeprecated2() {
-		Class[] classes = new Class[]{
+		Class[] classes = new Class[] {
 				String[].class
 		};
 		assertTrue(hasDeprecationAnnotationConstructor(classes));
@@ -240,7 +238,7 @@ public class TestAll {
 
 	@Test
 	public void testDomainShardingConstructorDeprecated3() {
-		Class[] classes = new Class[]{
+		Class[] classes = new Class[] {
 				String[].class, boolean.class
 		};
 		assertTrue(hasDeprecationAnnotationConstructor(classes));
@@ -248,7 +246,7 @@ public class TestAll {
 
 	@Test
 	public void testDomainShardingConstructorDeprecated4() {
-		Class[] classes = new Class[]{
+		Class[] classes = new Class[] {
 				String[].class, boolean.class, String.class
 		};
 		assertTrue(hasDeprecationAnnotationConstructor(classes));
@@ -268,7 +266,7 @@ public class TestAll {
 			e.printStackTrace();
 		}
 
-		for (Annotation annotation : annotations){
+		for (Annotation annotation : annotations) {
 			if(annotation.annotationType().equals(Deprecated.class)) {
 				return true;
 			}
@@ -286,14 +284,13 @@ public class TestAll {
 			e.printStackTrace();
 		}
 
-		for (Annotation annotation : annotations){
+		for (Annotation annotation : annotations) {
 			if(annotation.annotationType().equals(Deprecated.class)) {
 				return true;
 			}
 		}
 
 		return false;
-
 	}
 
 	private static String extractDomain(String url) {

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -258,36 +258,20 @@ public class TestAll {
 	}
 
 	private boolean hasDeprecationAnnotationConstructor(Class[] classes) {
-		Annotation[] annotations = new Annotation[0];
-
 		try {
-			annotations = URLBuilder.class.getConstructor(classes).getAnnotations();
+			return URLBuilder.class.getConstructor(classes).isAnnotationPresent(Deprecated.class);
 		} catch (NoSuchMethodException e) {
 			e.printStackTrace();
-		}
-
-		for (Annotation annotation : annotations) {
-			if(annotation.annotationType().equals(Deprecated.class)) {
-				return true;
-			}
 		}
 
 		return false;
 	}
 
 	private boolean hasDeprecationAnnotationMethod(String name, Class type) {
-		Annotation[] annotations = new Annotation[0];
-
 		try {
-			annotations = URLBuilder.class.getDeclaredMethod(name,type).getAnnotations();
+			return URLBuilder.class.getDeclaredMethod(name,type).isAnnotationPresent(Deprecated.class);
 		} catch (NoSuchMethodException e) {
 			e.printStackTrace();
-		}
-
-		for (Annotation annotation : annotations) {
-			if(annotation.annotationType().equals(Deprecated.class)) {
-				return true;
-			}
 		}
 
 		return false;


### PR DESCRIPTION
This PR begins the process of deprecating, and eventually removing, domain sharding from the imgix-java library.
The `UrlBuilder` object will now generate a warning when users attempt to initialize it by passing in multiple domains in the form of an array or invoke the `setShardStrategy()` method.