### PR TITLE
refactor: rename `signWithLibraryParameter` to `includeLibraryParam`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ before_install:
 - ./gradlew clean
 language: java
 jdk:
-- oraclejdk8
+- openjdk11
+- openjdk8
 script: ./gradlew test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-5.4-bin.zip

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -17,7 +17,7 @@ public class URLBuilder {
 	private boolean useHttps;
 	private String signKey;
 	private ShardStrategy shardStrategy;
-	private boolean signWithLibraryParameter;
+	private boolean includeLibraryParam;
 
 	private int shardCycleNextIndex = 0;
 
@@ -26,7 +26,7 @@ public class URLBuilder {
 	 * 				and will be removed in the next major version.
 	 */
 	@Deprecated
-	public URLBuilder(String[] domains, boolean useHttps, String signKey, ShardStrategy shardStrategy, boolean signWithLibraryParameter) {
+	public URLBuilder(String[] domains, boolean useHttps, String signKey, ShardStrategy shardStrategy, boolean includeLibraryParam) {
 
 		if (domains == null || domains.length == 0) {
 			throw new IllegalArgumentException("At lease one domain must be passed to URLBuilder");
@@ -36,7 +36,7 @@ public class URLBuilder {
 		this.useHttps = useHttps;
 		this.signKey = signKey;
 		this.shardStrategy = shardStrategy;
-		this.signWithLibraryParameter = signWithLibraryParameter;
+		this.includeLibraryParam = includeLibraryParam;
 	}
 
 	public URLBuilder(String domain) {
@@ -120,7 +120,7 @@ public class URLBuilder {
 			domain = domains[0];
 		}
 
-		if (this.signWithLibraryParameter) {
+		if (this.includeLibraryParam) {
 			params.put("ixlib", "java-" + VERSION);
 		}
 


### PR DESCRIPTION
This PR renames the boolean parameter used by `URLBuilder` for signing urls with the `ixlib` parameter. 

Edit: Unrelated to this PR, travis was [breaking](https://github.com/travis-ci/travis-ci/issues/10290) due to `oraclejdk8` (the java version specified in `travis.yml`) no longer being available in those builds. A few changes were needed to remediate this: first I switched to `openjdk8` as [suggested online](https://travis-ci.community/t/the-travis-ci-build-could-not-be-completed-due-to-an-error/1345). I also took this opportunity to add `openjdk11` to increase the scope of our testing. Finally, I upgraded the [gradle wrapper version](https://stackoverflow.com/a/54359875) as the original one did not support JDK 11. An [alternative approach](https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476) that would keep `oraclejdk8` would be to specify `dist: trusty` in the `travis.yml` file.