### PR TITLE
feat: add srcset generation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,51 @@ public class ImgixExample {
 // Prints out:
 // http://demos.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4
 ```
+
+
+Srcset Generation
+-----------
+
+The imgix-java library allows for generation of custom `srcset` attributes, which can be invoked through `createSrcSet()`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.
+
+```java
+URLBuilder ub = new URLBuilder("demos.imgix.net", true, "my-token", false);
+String srcset = ub.createSrcSet("bridge.png");
+System.out.println(srcset);
+```
+
+Will produce the following attribute value, which can then be served to the client:
+
+```html
+https://demos.imgix.net/bridge.png?w=100&s=494158d968e94ac8e83772ada9a83ad1 100w,
+https://demos.imgix.net/bridge.png?w=116&s=6a22236e189b6a9548b531330647ffa7 116w,
+https://demos.imgix.net/bridge.png?w=134&s=cbf91f556dd67c0b9e26cb9784a83794 134w,
+                                    ...
+https://demos.imgix.net/bridge.png?w=7400&s=503e3ba04588f1c301863c9a5d84fe91 7400w,
+https://demos.imgix.net/bridge.png?w=8192&s=152551ce4ec155f7a03f60f762a1ca33 8192w
+```
+
+In cases where enough information is provided about an image's dimensions, `createSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w` (width), `h` (height), and `ar` (aspect ratio). By invoking `createSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
+
+```java
+URLBuilder ub = new URLBuilder("demos.imgix.net", true, "my-token", false);
+HashMap<String,String> params = new HashMap<String,String> ();
+params.put("h", "200");
+params.put("ar", "3:2");
+params.put("fit", "crop");
+String srcset = ub.createSrcSet("bridge.png", params);
+System.out.println(srcset);
+
+```
+
+Will produce the following attribute value:
+
+```html
+https://demos.imgix.net/bridge.png?ar=3%3A2&dpr=1&fit=crop&h=200&s=4c79373f535df7e2594a8f6622ec6631 1x,
+https://demos.imgix.net/bridge.png?ar=3%3A2&dpr=2&fit=crop&h=200&s=dc818ae4522494f2f750651304a4d825 2x,
+https://demos.imgix.net/bridge.png?ar=3%3A2&dpr=3&fit=crop&h=200&s=ba1ec0cef6c77ff02330d40cc4dae932 3x,
+https://demos.imgix.net/bridge.png?ar=3%3A2&dpr=4&fit=crop&h=200&s=b51e497d9461be62354c0ea12b6524fb 4x,
+https://demos.imgix.net/bridge.png?ar=3%3A2&dpr=5&fit=crop&h=200&s=dc37c1fbee505d425ca8e3764b37f791 5x
+```
+
+For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -93,7 +93,7 @@ public class URLBuilder {
 			srcset += this.createURL(path, params) + " " + width + "w,\n";
 		}
 
-		return srcset.substring(0,srcset.length()-2);
+		return srcset.substring(0, srcset.length() - 2);
 	}
 
 	private String createSrcSetDPR(String path, Map<String, String> params) {
@@ -101,23 +101,23 @@ public class URLBuilder {
 		int[] srcsetTargetRatios = {1,2,3,4,5};
 
 		for (int ratio: srcsetTargetRatios) {
-
 			params.put("dpr", Integer.toString(ratio));
 			srcset += this.createURL(path, params) + " " + ratio + "x,\n";
 		}
 
-		return srcset.substring(0,srcset.length()-2);
+		return srcset.substring(0, srcset.length() - 2);
 	}
 
 	private static ArrayList<Integer> targetWidths() {
 		ArrayList<Integer> resolutions = new ArrayList<Integer>();
-		int MAX_SIZE = 8192;
+		int MAX_SIZE = 8192, roundedPrev;
 		double SRCSET_INCREMENT_PERCENTAGE = 8;
 		double prev = 100;
 
-		while (prev <= MAX_SIZE) {
+		while (prev < MAX_SIZE) {
 			// ensures the added width is even
-			resolutions.add((int)(2 * Math.round(prev/2)));
+			roundedPrev = (int)(2 * Math.round(prev / 2));
+			resolutions.add(roundedPrev);
 			prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100) * 2;
 		}
 		resolutions.add(MAX_SIZE);

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -1,5 +1,7 @@
 package com.imgix;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -11,6 +13,7 @@ public class URLBuilder {
 	private boolean useHttps;
 	private String signKey;
 	private boolean includeLibraryParam;
+	private final ArrayList<Integer> SRCSET_TARGET_WIDTHS = this.targetWidths();
 
 	public URLBuilder(String domain, boolean useHttps, String signKey, boolean includeLibraryParam) {
 
@@ -57,6 +60,72 @@ public class URLBuilder {
 		}
 
 		return new URLHelper(domain, path, scheme, signKey, params).getURL();
+	}
+
+	public String createSrcSet(String path) {
+		return createSrcSet(path, new HashMap<String, String>());
+	}
+
+	public String createSrcSet(String path, HashMap<String, String> params) {
+		String width = params.get("w");
+		String height = params.get("h");
+		String aspectRatio = params.get("ar");
+
+		/* builds a DPR srcset if either:
+			   a width or
+			   a height and an aspect ratio
+		   are provided, otherwise builds a
+		   srcset of width-pairs
+		 */
+		if (!(width == null || width.isEmpty())
+				|| !((height == null || height.isEmpty())
+				|| (aspectRatio == null || aspectRatio.isEmpty()))) {
+			return createSrcSetDPR(path, params);
+		} else {
+			return createSrcSetPairs(path, params);
+		}
+	}
+
+	private String createSrcSetPairs(String path, HashMap<String, String> params) {
+		String srcset = "";
+
+		for (Integer width: this.SRCSET_TARGET_WIDTHS
+			 ) {
+			params.put("w", width.toString());
+			srcset += this.createURL(path, params) + " " + width + "w,\n";
+		}
+
+		return srcset.substring(0,srcset.length()-2);
+	}
+
+	private String createSrcSetDPR(String path, HashMap<String, String> params) {
+		String srcset = "";
+		int[] srcsetTargetRatios = {1,2,3,4,5};
+
+		for (int ratio: srcsetTargetRatios
+			 ) {
+
+			params.put("dpr", Integer.toString(ratio));
+			srcset += this.createURL(path, params) + " " + ratio + "x,\n";
+		}
+
+		return srcset.substring(0,srcset.length()-2);
+	}
+
+	private static ArrayList<Integer> targetWidths() {
+		ArrayList<Integer> resolutions = new ArrayList<Integer>();
+		int MAX_SIZE = 8192;
+		double SRCSET_INCREMENT_PERCENTAGE = 8;
+		double prev = 100;
+
+		while (prev <= MAX_SIZE) {
+			// ensures the added width is even
+			resolutions.add((int)(2 * Math.round(prev/2)));
+			prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100) * 2;
+		}
+		resolutions.add(MAX_SIZE);
+
+		return resolutions;
 	}
 
 	public static void main(String[] args) {

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -89,8 +89,7 @@ public class URLBuilder {
 	private String createSrcSetPairs(String path, HashMap<String, String> params) {
 		String srcset = "";
 
-		for (Integer width: this.SRCSET_TARGET_WIDTHS
-			 ) {
+		for (Integer width: this.SRCSET_TARGET_WIDTHS) {
 			params.put("w", width.toString());
 			srcset += this.createURL(path, params) + " " + width + "w,\n";
 		}
@@ -102,8 +101,7 @@ public class URLBuilder {
 		String srcset = "";
 		int[] srcsetTargetRatios = {1,2,3,4,5};
 
-		for (int ratio: srcsetTargetRatios
-			 ) {
+		for (int ratio: srcsetTargetRatios) {
 
 			params.put("dpr", Integer.toString(ratio));
 			srcset += this.createURL(path, params) + " " + ratio + "x,\n";

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -1,7 +1,6 @@
 package com.imgix;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -63,10 +62,10 @@ public class URLBuilder {
 	}
 
 	public String createSrcSet(String path) {
-		return createSrcSet(path, new HashMap<String, String>());
+		return createSrcSet(path, new TreeMap<String, String>());
 	}
 
-	public String createSrcSet(String path, HashMap<String, String> params) {
+	public String createSrcSet(String path, Map<String, String> params) {
 		String width = params.get("w");
 		String height = params.get("h");
 		String aspectRatio = params.get("ar");
@@ -86,7 +85,7 @@ public class URLBuilder {
 		}
 	}
 
-	private String createSrcSetPairs(String path, HashMap<String, String> params) {
+	private String createSrcSetPairs(String path, Map<String, String> params) {
 		String srcset = "";
 
 		for (Integer width: this.SRCSET_TARGET_WIDTHS) {
@@ -97,7 +96,7 @@ public class URLBuilder {
 		return srcset.substring(0,srcset.length()-2);
 	}
 
-	private String createSrcSetDPR(String path, HashMap<String, String> params) {
+	private String createSrcSetDPR(String path, Map<String, String> params) {
 		String srcset = "";
 		int[] srcsetTargetRatios = {1,2,3,4,5};
 

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -1,0 +1,564 @@
+package com.imgix.test;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import static org.junit.Assert.*;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+
+import com.imgix.URLBuilder;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+
+@RunWith(JUnit4.class)
+public class TestSrcSet {
+
+    private static HashMap<String, String> params;
+    private static String[] srcsetSplit;
+    private static String[] srcsetWidthSplit;
+    private static String[] srcsetHeightSplit;
+    private static String[] srcsetAspectRatioSplit;
+    private static String[] srcsetWidthAndHeightSplit;
+    private static String[] srcsetWidthAndAspectRatioSplit;
+    private static String[] srcsetHeightAndAspectRatioSplit;
+
+    @BeforeClass
+    public static void buildAllSrcSets() {
+        String srcset, srcsetWidth, srcsetHeight, srcsetAspectRatio, srcsetWidthAndHeight, srcsetWidthAndAspectRatio, srcsetHeightAndAspectRatio;
+
+        URLBuilder ub = new URLBuilder("test.imgix.net", true, "MYT0KEN" , false);
+        params = new HashMap<String, String>();
+
+        srcset = ub.createSrcSet("image.jpg");
+        srcsetSplit = srcset.split(",");
+
+        params.put("w","300");
+        srcsetWidth = ub.createSrcSet("image.jpg", params);
+        srcsetWidthSplit = srcsetWidth.split(",");
+        params.clear();
+
+        params.put("h","300");
+        srcsetHeight = ub.createSrcSet("image.jpg", params);
+        srcsetHeightSplit = srcsetHeight.split(",");
+        params.clear();
+
+        params.put("ar","3:2");
+        srcsetAspectRatio = ub.createSrcSet("image.jpg", params);
+        srcsetAspectRatioSplit = srcsetAspectRatio.split(",");
+        params.clear();
+
+        params.put("w","300");
+        params.put("h","300");
+        srcsetWidthAndHeight = ub.createSrcSet("image.jpg", params);
+        srcsetWidthAndHeightSplit = srcsetWidthAndHeight.split(",");
+        params.clear();
+
+        params.put("w","300");
+        params.put("ar","3:2");
+        srcsetWidthAndAspectRatio = ub.createSrcSet("image.jpg", params);
+        srcsetWidthAndAspectRatioSplit = srcsetWidthAndAspectRatio.split(",");
+        params.clear();
+
+        params.put("h","300");
+        params.put("ar","3:2");
+        srcsetHeightAndAspectRatio = ub.createSrcSet("image.jpg", params);
+        srcsetHeightAndAspectRatioSplit = srcsetHeightAndAspectRatio.split(",");
+        params.clear();
+    }
+
+    @Test
+    public void testNoParametersGeneratesCorrectWidths() {
+        int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+
+        String generatedWidth;
+        int index = 0;
+        int widthInt;
+
+        for (String src: srcsetSplit) {
+            generatedWidth = src.split(" ")[1];
+            widthInt = Integer.parseInt(generatedWidth.substring(0,generatedWidth.length()-1));
+            assertEquals(targetWidths[index], widthInt);
+            index++;
+        }
+    }
+
+    @Test
+    public void testNoParametersReturnsExpectedNumberOfPairs() {
+        int expectedPairs = 31;
+        assertEquals(expectedPairs, srcsetSplit.length);
+    }
+
+    @Test
+    public void testNoParametersDoesNotExceedBounds() {
+        String minWidth = srcsetSplit[0].split(" ")[1];
+        String maxWidth = srcsetSplit[srcsetSplit.length-1].split(" ")[1];
+
+        int minWidthInt = Integer.parseInt(minWidth.substring(0,minWidth.length()-1));
+        int maxWidthInt = Integer.parseInt(maxWidth.substring(0,maxWidth.length()-1));
+
+        assert(minWidthInt >= 100);
+        assert(maxWidthInt <= 8192);
+    }
+
+    // a 17% testing threshold is used to account for rounding
+    @Test
+    public void testNoParametersDoesNotIncreaseMoreThan17Percent() {
+        final double INCREMENT_ALLOWED = .17;
+        String width;
+        int widthInt, prev;
+
+        // convert and store first width (typically: 100)
+        width = srcsetSplit[0].split(" ")[1];
+        prev = Integer.parseInt(width.substring(0,width.length()-1));
+
+        for (String src : srcsetSplit) {
+            width = src.split(" ")[1];
+            widthInt = Integer.parseInt(width.substring(0,width.length()-1));
+
+            assert((widthInt / prev) < (1 + INCREMENT_ALLOWED));
+            prev = widthInt;
+        }
+    }
+
+    @Test
+    public void testNoParametersSignsUrls() {
+        String src, parameters, generatedSignature, expectedSignature = "", signatureBase;
+
+        for (String srcLine : srcsetSplit) {
+
+            src = srcLine.split(" ")[0];
+            assert(src.contains("s="));
+            generatedSignature = src.substring(src.indexOf("s=")+2);
+
+            parameters = src.substring(src.indexOf("?"), src.indexOf("s=")-1);
+            signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+            // create MD5 hash
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                byte[] array = md.digest(signatureBase.getBytes("UTF-8"));
+                StringBuffer sb = new StringBuffer();
+                for (int x = 0; x < array.length; ++x) {
+                    sb.append(Integer.toHexString((array[x] & 0xFF) | 0x100).substring(1,3));
+                }
+                expectedSignature = sb.toString();
+            } catch (UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
+            }
+
+            assertEquals(expectedSignature, generatedSignature);
+        }
+    }
+
+    @Test
+    public void testWidthInDPRForm() {
+        String generatedRatio;
+        int expectedRatio = 1;
+        assert(srcsetWidthSplit.length == 5);
+
+        for (String src: srcsetWidthSplit) {
+            generatedRatio = src.split(" ")[1];
+            assertEquals(expectedRatio + "x", generatedRatio);
+            expectedRatio++;
+        }
+    }
+
+    @Test
+    public void testWidthSignsUrls() {
+        String src, parameters, generatedSignature, expectedSignature = "", signatureBase;
+
+        for (String srcLine : srcsetWidthSplit) {
+
+            src = srcLine.split(" ")[0];
+            assert(src.contains("s="));
+            generatedSignature = src.substring(src.indexOf("s=")+2);
+
+            parameters = src.substring(src.indexOf("?"), src.indexOf("s=")-1);
+            signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+            // create MD5 hash
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                byte[] array = md.digest(signatureBase.getBytes("UTF-8"));
+                StringBuffer sb = new StringBuffer();
+                for (int x = 0; x < array.length; ++x) {
+                    sb.append(Integer.toHexString((array[x] & 0xFF) | 0x100).substring(1,3));
+                }
+                expectedSignature = sb.toString();
+            } catch (UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
+            }
+
+            assertEquals(expectedSignature, generatedSignature);
+        }
+    }
+
+    @Test
+    public void testWidthIncludesDPRParam() {
+        String src;
+
+        for (int i = 0; i < srcsetWidthSplit.length; i++) {
+            src = srcsetWidthSplit[i].split(" ")[0];
+            assert(src.contains(String.format("dpr=%s", i+1)));
+        }
+    }
+
+    @Test
+    public void testHeightGeneratesCorrectWidths() {
+        int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+
+        String generatedWidth;
+        int index = 0;
+        int widthInt;
+
+        for (String src: srcsetHeightSplit) {
+            generatedWidth = src.split(" ")[1];
+            widthInt = Integer.parseInt(generatedWidth.substring(0,generatedWidth.length()-1));
+            assertEquals(targetWidths[index], widthInt);
+            index++;
+        }
+    }
+
+    @Test
+    public void testHeightContainsHeightParameter() {
+        String url;
+
+        for (String src: srcsetHeightSplit) {
+            url = src.split(" ")[0];
+            assert(url.contains("h="));
+        }
+    }
+
+    @Test
+    public void testHeightReturnsExpectedNumberOfPairs() {
+        int expectedPairs = 31;
+        assertEquals(expectedPairs, srcsetHeightSplit.length);
+    }
+
+    @Test
+    public void testHeightDoesNotExceedBounds() {
+        String minWidth = srcsetHeightSplit[0].split(" ")[1];
+        String maxWidth = srcsetHeightSplit[srcsetHeightSplit.length-1].split(" ")[1];
+
+        int minWidthInt = Integer.parseInt(minWidth.substring(0,minWidth.length()-1));
+        int maxWidthInt = Integer.parseInt(maxWidth.substring(0,maxWidth.length()-1));
+
+        assert(minWidthInt >= 100);
+        assert(maxWidthInt <= 8192);
+    }
+
+    // a 17% testing threshold is used to account for rounding
+    @Test
+    public void testHeightDoesNotIncreaseMoreThan17Percent() {
+        final double INCREMENT_ALLOWED = .17;
+        String width;
+        int widthInt, prev;
+
+        // convert and store first width (typically: 100)
+        width = srcsetHeightSplit[0].split(" ")[1];
+        prev = Integer.parseInt(width.substring(0,width.length()-1));
+
+        for (String src : srcsetHeightSplit) {
+            width = src.split(" ")[1];
+            widthInt = Integer.parseInt(width.substring(0,width.length()-1));
+
+            assert((widthInt / prev) < (1 + INCREMENT_ALLOWED));
+            prev = widthInt;
+        }
+    }
+
+    @Test
+    public void testHeightSignsUrls() {
+        String src, parameters, generatedSignature, expectedSignature = "", signatureBase;
+
+        for (String srcLine : srcsetHeightSplit) {
+
+            src = srcLine.split(" ")[0];
+            assert(src.contains("s="));
+            generatedSignature = src.substring(src.indexOf("s=")+2);
+
+            parameters = src.substring(src.indexOf("?"), src.indexOf("s=")-1);
+            signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+            // create MD5 hash
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                byte[] array = md.digest(signatureBase.getBytes("UTF-8"));
+                StringBuffer sb = new StringBuffer();
+                for (int x = 0; x < array.length; ++x) {
+                    sb.append(Integer.toHexString((array[x] & 0xFF) | 0x100).substring(1,3));
+                }
+                expectedSignature = sb.toString();
+            } catch (UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
+            }
+
+            assertEquals(expectedSignature, generatedSignature);
+        }
+    }
+
+    @Test
+    public void testWidthAndHeightInDPRForm() {
+        String generatedRatio;
+        int expectedRatio = 1;
+        assert(srcsetWidthAndHeightSplit.length == 5);
+
+        for (String src: srcsetWidthAndHeightSplit) {
+            generatedRatio = src.split(" ")[1];
+            assertEquals(expectedRatio + "x", generatedRatio);
+            expectedRatio++;
+        }
+    }
+
+    @Test
+    public void testWidthAndHeightSignsUrls() {
+        String src, parameters, generatedSignature, expectedSignature = "", signatureBase;
+
+        for (String srcLine : srcsetWidthAndHeightSplit) {
+
+            src = srcLine.split(" ")[0];
+            assert(src.contains("s="));
+            generatedSignature = src.substring(src.indexOf("s=")+2);
+
+            parameters = src.substring(src.indexOf("?"), src.indexOf("s=")-1);
+            signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+            // create MD5 hash
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                byte[] array = md.digest(signatureBase.getBytes("UTF-8"));
+                StringBuffer sb = new StringBuffer();
+                for (int x = 0; x < array.length; ++x) {
+                    sb.append(Integer.toHexString((array[x] & 0xFF) | 0x100).substring(1,3));
+                }
+                expectedSignature = sb.toString();
+            } catch (UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
+            }
+
+            assertEquals(expectedSignature, generatedSignature);
+        }
+    }
+
+    @Test
+    public void testWidthAndHeightIncludesDPRParam() {
+        String src;
+
+        for (int i = 0; i < srcsetWidthAndHeightSplit.length; i++) {
+            src = srcsetWidthAndHeightSplit[i].split(" ")[0];
+            assert(src.contains(String.format("dpr=%s", i+1)));
+        }
+    }
+
+    @Test
+    public void testAspectRatioGeneratesCorrectWidths() {
+        int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+
+        String generatedWidth;
+        int index = 0;
+        int widthInt;
+
+        for (String src: srcsetAspectRatioSplit) {
+            generatedWidth = src.split(" ")[1];
+            widthInt = Integer.parseInt(generatedWidth.substring(0,generatedWidth.length()-1));
+            assertEquals(targetWidths[index], widthInt);
+            index++;
+        }
+    }
+
+    @Test
+    public void testAspectRatioContainsARParameter() {
+        String url;
+
+        for (String src: srcsetAspectRatioSplit) {
+            url = src.split(" ")[0];
+            assert(url.contains("ar="));
+        }
+    }
+
+    @Test
+    public void testAspectRatioReturnsExpectedNumberOfPairs() {
+        int expectedPairs = 31;
+        assertEquals(expectedPairs, srcsetAspectRatioSplit.length);
+    }
+
+    @Test
+    public void testAspectRatioDoesNotExceedBounds() {
+        String minWidth = srcsetAspectRatioSplit[0].split(" ")[1];
+        String maxWidth = srcsetAspectRatioSplit[srcsetAspectRatioSplit.length-1].split(" ")[1];
+
+        int minWidthInt = Integer.parseInt(minWidth.substring(0,minWidth.length()-1));
+        int maxWidthInt = Integer.parseInt(maxWidth.substring(0,maxWidth.length()-1));
+
+        assert(minWidthInt >= 100);
+        assert(maxWidthInt <= 8192);
+    }
+
+    // a 17% testing threshold is used to account for rounding
+    @Test
+    public void testAspectRatioDoesNotIncreaseMoreThan17Percent() {
+        final double INCREMENT_ALLOWED = .17;
+        String width;
+        int widthInt, prev;
+
+        // convert and store first width (typically: 100)
+        width = srcsetAspectRatioSplit[0].split(" ")[1];
+        prev = Integer.parseInt(width.substring(0,width.length()-1));
+
+        for (String src : srcsetAspectRatioSplit) {
+            width = src.split(" ")[1];
+            widthInt = Integer.parseInt(width.substring(0,width.length()-1));
+
+            assert((widthInt / prev) < (1 + INCREMENT_ALLOWED));
+            prev = widthInt;
+        }
+    }
+
+    @Test
+    public void testAspectRatioSignsUrls() {
+        String src, parameters, generatedSignature, expectedSignature = "", signatureBase;
+
+        for (String srcLine : srcsetAspectRatioSplit) {
+
+            src = srcLine.split(" ")[0];
+            assert(src.contains("s="));
+            generatedSignature = src.substring(src.indexOf("s=")+2);
+
+            parameters = src.substring(src.indexOf("?"), src.indexOf("s=")-1);
+            signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+            // create MD5 hash
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                byte[] array = md.digest(signatureBase.getBytes("UTF-8"));
+                StringBuffer sb = new StringBuffer();
+                for (int x = 0; x < array.length; ++x) {
+                    sb.append(Integer.toHexString((array[x] & 0xFF) | 0x100).substring(1,3));
+                }
+                expectedSignature = sb.toString();
+            } catch (UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
+            }
+
+            assertEquals(expectedSignature, generatedSignature);
+        }
+    }
+
+    @Test
+    public void testWidthAndAspectRatioInDPRForm() {
+        String generatedRatio;
+        int expectedRatio = 1;
+        assert(srcsetWidthAndAspectRatioSplit.length == 5);
+
+        for (String src: srcsetWidthAndAspectRatioSplit) {
+            generatedRatio = src.split(" ")[1];
+            assertEquals(expectedRatio + "x", generatedRatio);
+            expectedRatio++;
+        }
+    }
+
+    @Test
+    public void testWidthAndAspectRatioSignsUrls() {
+        String src, parameters, generatedSignature, expectedSignature = "", signatureBase;
+
+        for (String srcLine : srcsetWidthAndAspectRatioSplit) {
+
+            src = srcLine.split(" ")[0];
+            assert(src.contains("s="));
+            generatedSignature = src.substring(src.indexOf("s=")+2);
+
+            parameters = src.substring(src.indexOf("?"), src.indexOf("s=")-1);
+            signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+            // create MD5 hash
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                byte[] array = md.digest(signatureBase.getBytes("UTF-8"));
+                StringBuffer sb = new StringBuffer();
+                for (int x = 0; x < array.length; ++x) {
+                    sb.append(Integer.toHexString((array[x] & 0xFF) | 0x100).substring(1,3));
+                }
+                expectedSignature = sb.toString();
+            } catch (UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
+            }
+
+            assertEquals(expectedSignature, generatedSignature);
+        }
+    }
+
+    @Test
+    public void testWidthAndAspectRatioIncludesDPRParam() {
+        String src;
+
+        for (int i = 0; i < srcsetWidthAndAspectRatioSplit.length; i++) {
+            src = srcsetWidthAndAspectRatioSplit[i].split(" ")[0];
+            assert(src.contains(String.format("dpr=%s", i+1)));
+        }
+    }
+
+    @Test
+    public void testHeightAndAspectRatioInDPRForm() {
+        String generatedRatio;
+        int expectedRatio = 1;
+        assert(srcsetHeightAndAspectRatioSplit.length == 5);
+
+        for (String src: srcsetHeightAndAspectRatioSplit) {
+            generatedRatio = src.split(" ")[1];
+            assertEquals(expectedRatio + "x", generatedRatio);
+            expectedRatio++;
+        }
+    }
+
+    @Test
+    public void testHeightAndAspectRatioSignsUrls() {
+        String src, parameters, generatedSignature, expectedSignature = "", signatureBase;
+
+        for (String srcLine : srcsetHeightAndAspectRatioSplit) {
+
+            src = srcLine.split(" ")[0];
+            assert(src.contains("s="));
+            generatedSignature = src.substring(src.indexOf("s=")+2);
+
+            parameters = src.substring(src.indexOf("?"), src.indexOf("s=")-1);
+            signatureBase = "MYT0KEN" + "/image.jpg" + parameters;
+
+            // create MD5 hash
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                byte[] array = md.digest(signatureBase.getBytes("UTF-8"));
+                StringBuffer sb = new StringBuffer();
+                for (int x = 0; x < array.length; ++x) {
+                    sb.append(Integer.toHexString((array[x] & 0xFF) | 0x100).substring(1,3));
+                }
+                expectedSignature = sb.toString();
+            } catch (UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
+            }
+
+            assertEquals(expectedSignature, generatedSignature);
+        }
+    }
+
+    @Test
+    public void testHeightAndAspectRatioIncludesDPRParam() {
+        String src;
+
+        for (int i = 0; i < srcsetHeightAndAspectRatioSplit.length; i++) {
+            src = srcsetHeightAndAspectRatioSplit[i].split(" ")[0];
+            assert(src.contains(String.format("dpr=%s", i+1)));
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a new class method in `URLBuilder` that will generate a `srcset` string, which can be used in the `srcset` attribute on an `<img>` HTML element. `createSrcSet()` takes a `path` and `params` argument similar to `createURL()`, and will return a `String` in one of two `srcset` formats.

**Srcset Width-Pairs**
The first format creates `srcset` width-pairs, a comma-delimited list of URLs and width descriptors corresponding to each one. This allows for responsive size switching based on the current width of the browser viewport. `createSrcSet()` will append any `params` passed to the method to each URL constructed within the list. The following is an example of how to generate a width-pair `srcset`:
```java
URLBuilder ub = new URLBuilder("test.imgix.net", true, "", false);
HashMap<String,String> params = new HashMap<String,String> ();
params.put("fit", "crop");
params.put("crop", "faces");
System.out.println(ub.createSrcSet("bridge.png", params));
```
will return the following `String` (collapsed for brevity):
```html
https://test.imgix.net/bridge.png?crop=faces&fit=crop&w=100 100w,
https://test.imgix.net/bridge.png?crop=faces&fit=crop&w=116 116w,
https://test.imgix.net/bridge.png?crop=faces&fit=crop&w=134 134w,
											...
https://test.imgix.net/bridge.png?crop=faces&fit=crop&w=7400 7400w,
https://test.imgix.net/bridge.png?crop=faces&fit=crop&w=8192 8192w
```
Notice that a `w=` parameter is automatically inserted for each entry in the `srcset` list. This is required in order for the element to properly display the correctly-sized image corresponding to the viewport's width.

**Device Pixel Ratio (DPR) Srcset**
The second format this method can return is a `srcset` list of same-size images in varying resolutions. In this case, images are scaled using the `dpr=` parameter to adjust for the [device pixel ratio](https://docs.imgix.com/apis/url/pixel-density/dpr) of the browser. A DPR `srcset` will be automatically generated instead of a width-pair srcset if exact dimensions for the output image are specified, by providing either a `w` (width) **or** a `h` (height) and `ar` (aspect ratio) in the `params` argument.
The following is an example of how to generate a DPR `srcset`:
```java
URLBuilder ub = new URLBuilder("test.imgix.net", true, "", false);
HashMap<String,String> params = new HashMap<String,String> ();
params.put("h", "200");
params.put("ar", "3:2");

System.out.println(ub.createSrcSet("bridge.png", params));
```
which will return the following `String`:
```html
https://test.imgix.net/bridge.png?ar=3%3A2&dpr=1&h=200 1x,
https://test.imgix.net/bridge.png?ar=3%3A2&dpr=2&h=200 2x,
https://test.imgix.net/bridge.png?ar=3%3A2&dpr=3&h=200 3x,
https://test.imgix.net/bridge.png?ar=3%3A2&dpr=4&h=200 4x,
https://test.imgix.net/bridge.png?ar=3%3A2&dpr=5&h=200 5x
```
---
**Signing URLs**
`createSrcSet()` also supports signing URLs, which can be very useful for generating server-side and then passing to the client. This will avoid having to expose your imgix source's secure token to the client.
```java
URLBuilder ub = new URLBuilder("test.imgix.net", true, "my-token", false);
HashMap<String,String> params = new HashMap<String,String> ();
params.put("w", "100");
System.out.println(ub.createSrcSet("bridge.png", params));
```
generates a `srcset` with unique signatures for each URL:
```html
https://test.imgix.net/bridge.png?dpr=1&w=100&s=f461367db3c5fad8ae9d18864b38533a 1x,
https://test.imgix.net/bridge.png?dpr=2&w=100&s=9cac4c9fa5a263cef1ca443340a64a2c 2x,
https://test.imgix.net/bridge.png?dpr=3&w=100&s=29a0aa19b074a000de96eb4f1a24803b 3x,
https://test.imgix.net/bridge.png?dpr=4&w=100&s=f16ac140640d46ed8499102730e1f62d 4x,
https://test.imgix.net/bridge.png?dpr=5&w=100&s=3ef7c404f749ed5296fe0b6de47d8d2f 5x
```
---
For more information on `srcset`, building responsive images, and resolution switching:
- [Responsive images - MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
- [Srcset and Sizes - Eric Portis](https://ericportis.com/posts/2014/srcset-sizes/)