### PR TITLE
fix: add domain validation during URLBuilder initialization

### DIFF
--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -2,10 +2,12 @@ package com.imgix;
 
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 public class URLBuilder {
 
 	public static final String VERSION = "2.0.0";
+	private static final String DOMAIN_REGEX = "^(?:[a-z\\d\\-_]{1,62}\\.){0,125}(?:[a-z\\d](?:\\-(?=\\-*[a-z\\d])|[a-z]|\\d){0,62}\\.)[a-z\\d]{1,63}$";
 
 	private String domain;
 	private boolean useHttps;
@@ -13,9 +15,12 @@ public class URLBuilder {
 	private boolean includeLibraryParam;
 
 	public URLBuilder(String domain, boolean useHttps, String signKey, boolean includeLibraryParam) {
+		Pattern domainPattern = Pattern.compile(DOMAIN_REGEX);
 
 		if (domain == null || domain.length() == 0) {
 			throw new IllegalArgumentException("At lease one domain must be passed to URLBuilder");
+		} else if (!domainPattern.matcher(domain).matches()) {
+			throw new IllegalArgumentException("Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. \"example.imgix.net\".");
 		}
 
 		this.domain = domain;

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -175,6 +175,24 @@ public class TestAll {
 		assertEquals(URLHelper.encodeURIComponent(URLHelper.decodeURIComponent(encodedUrl)), encodedUrl);
 	}
 
+	@Test
+	public void testInvalidDomainAppendSlash() {
+		exception.expect(IllegalArgumentException.class);
+		URLBuilder ub = new URLBuilder("test.imgix.net/");
+	}
+
+	@Test
+	public void testInvalidDomainPrependScheme() {
+		exception.expect(IllegalArgumentException.class);
+		URLBuilder ub = new URLBuilder("https://test.imgix.net");
+	}
+
+	@Test
+	public void testInvalidDomainAppendDash() {
+		exception.expect(IllegalArgumentException.class);
+		URLBuilder ub = new URLBuilder("test.imgix.net-");
+	}
+
 	private static String extractDomain(String url) {
 		try {
 			URI parsed = new URI(url);


### PR DESCRIPTION
This PR adds logic to validate that a `domain` passed into the `URLBuilder` constructor is valid. If the passed in String is found to be invalid, an `IllegalArgumentException` will be thrown. The criteria for evaluating the validity of a domain is based on the same pattern used on [dashboard.imgix.com](https://dashboard.imgix.com).