### PR TITLE
fix: explicitly convert string to UTF-8 byte array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ language: java
 jdk:
 - openjdk11
 - openjdk8
-script: ./gradlew test
+script:
+- ./gradlew test
+- ./gradlew testUTF32

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
 repositories {
-    maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "https://repo.maven.apache.org/maven2" }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+task testUTF32(type: Test) {
+    jvmArgs "-Dfile.encoding=UTF-32"
+}
+
 artifacts {
     archives sourcesJar
     archives javadocJar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -65,11 +65,13 @@ public class URLHelper {
 
 	private String encodeBase64(String str) {
 		byte[] stringBytes = new byte[0];
+		String b64EncodedString = null;
+
 		try {
 			stringBytes = str.getBytes("UTF-8");
+			b64EncodedString = new String(Base64.getEncoder().encode(stringBytes), "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 		}
-		String b64EncodedString = new String(Base64.getEncoder().encode(stringBytes));
 
 		b64EncodedString = b64EncodedString.replace("=", "");
 		b64EncodedString = b64EncodedString.replace('/', '_');

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -64,7 +64,11 @@ public class URLHelper {
 	}
 
 	private String encodeBase64(String str) {
-		byte[] stringBytes = str.getBytes();
+		byte[] stringBytes = new byte[0];
+		try {
+			stringBytes = str.getBytes("UTF-8");
+		} catch (UnsupportedEncodingException e) {
+		}
 		String b64EncodedString = new String(Base64.getEncoder().encode(stringBytes));
 
 		b64EncodedString = b64EncodedString.replace("=", "");

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.net.URLDecoder;
 
-import java.net.URISyntaxException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -64,13 +63,13 @@ public class URLHelper {
 	}
 
 	private String encodeBase64(String str) {
-		byte[] stringBytes = new byte[0];
 		String b64EncodedString = null;
 
 		try {
-			stringBytes = str.getBytes("UTF-8");
+			byte[] stringBytes = str.getBytes("UTF-8");
 			b64EncodedString = new String(Base64.getEncoder().encode(stringBytes), "UTF-8");
 		} catch (UnsupportedEncodingException e) {
+			throw new IllegalArgumentException(e);
 		}
 
 		b64EncodedString = b64EncodedString.replace("=", "");


### PR DESCRIPTION
This PR explicitly converts a query parameter value to UTF-8 before encoding the value to base64. Without specifying the encoding scheme explicitly, the behavior of `getBytes()` and the subsequent `String` instantiation would be platform dependent, which can result in incorrectly-encoded values. By specifying `UTF-8`, we can ensure the results regardless of the default charset of the calling system.
Fixes #35 