### PR TITLE
feat(https): use https by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 *.iml
 .idea/
 /.gradle
+.settings/
+.project

--- a/examples/com/imgix/examples/BasicUsage.java
+++ b/examples/com/imgix/examples/BasicUsage.java
@@ -3,11 +3,11 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class BasicUsage {
-	public static void main(String[] args) {
-		URLBuilder builder = new URLBuilder("demos.imgix.net");
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("w", "100");
-		params.put("h", "100");
-		System.out.println(builder.createURL("bridge.png", params));
-	}
+    public static void main(String[] args) {
+        URLBuilder builder = new URLBuilder("demos.imgix.net");
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("w", "100");
+        params.put("h", "100");
+        System.out.println(builder.createURL("bridge.png", params));
+    }
 }

--- a/examples/com/imgix/examples/CycleDomainSharding.java
+++ b/examples/com/imgix/examples/CycleDomainSharding.java
@@ -3,18 +3,18 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class CycleDomainSharding {
-	public static void main(String[] args) {
-		String[] domains = new String[] { "demos-1.imgix.net", "demos-2.imgix.net", "demos-3.imgix.net"};
-		URLBuilder builder = new URLBuilder(domains);
+    public static void main(String[] args) {
+        String[] domains = new String[] { "demos-1.imgix.net", "demos-2.imgix.net", "demos-3.imgix.net"};
+        URLBuilder builder = new URLBuilder(domains);
 
-		builder.setShardStratgy(URLBuilder.ShardStrategy.CYCLE);
+        builder.setShardStratgy(URLBuilder.ShardStrategy.CYCLE);
 
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("w", "100");
-		params.put("h", "100");
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("w", "100");
+        params.put("h", "100");
 
-		for (int i = 0; i < 4; i++) {
-			System.out.println(builder.createURL("bridge.png", params));
-		}
-	}
+        for (int i = 0; i < 4; i++) {
+            System.out.println(builder.createURL("bridge.png", params));
+        }
+    }
 }

--- a/examples/com/imgix/examples/DomainSharding.java
+++ b/examples/com/imgix/examples/DomainSharding.java
@@ -3,14 +3,14 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class DomainSharding {
-	public static void main(String[] args) {
-		String[] domains = new String[] { "demos-1.imgix.net", "demos-2.imgix.net", "demos-3.imgix.net"};
-		URLBuilder builder = new URLBuilder(domains);
+    public static void main(String[] args) {
+        String[] domains = new String[] { "demos-1.imgix.net", "demos-2.imgix.net", "demos-3.imgix.net"};
+        URLBuilder builder = new URLBuilder(domains);
 
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("w", "100");
-		params.put("h", "100");
-		System.out.println(builder.createURL("bridge.png", params));
-		System.out.println(builder.createURL("flower.png", params));
-	}
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("w", "100");
+        params.put("h", "100");
+        System.out.println(builder.createURL("bridge.png", params));
+        System.out.println(builder.createURL("flower.png", params));
+    }
 }

--- a/examples/com/imgix/examples/SignedURL.java
+++ b/examples/com/imgix/examples/SignedURL.java
@@ -3,12 +3,12 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class SignedURL {
-	public static void main(String[] args) {
-		URLBuilder builder = new URLBuilder("demos.imgix.net");
-		builder.setSignKey("test1234");
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("w", "100");
-		params.put("h", "100");
-		System.out.println(builder.createURL("bridge.png", params));
-	}
+    public static void main(String[] args) {
+        URLBuilder builder = new URLBuilder("demos.imgix.net");
+        builder.setSignKey("test1234");
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("w", "100");
+        params.put("h", "100");
+        System.out.println(builder.createURL("bridge.png", params));
+    }
 }

--- a/examples/com/imgix/examples/UseHttps.java
+++ b/examples/com/imgix/examples/UseHttps.java
@@ -3,12 +3,12 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class UseHttps {
-	public static void main(String[] args) {
-		URLBuilder builder = new URLBuilder("demos.imgix.net");
-		builder.setUseHttps(true);
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("w", "100");
-		params.put("h", "100");
-		System.out.println(builder.createURL("bridge.png", params));
-	}
+    public static void main(String[] args) {
+        URLBuilder builder = new URLBuilder("demos.imgix.net");
+        builder.setUseHttps(true);
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("w", "100");
+        params.put("h", "100");
+        System.out.println(builder.createURL("bridge.png", params));
+    }
 }

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -7,80 +7,80 @@ import java.util.regex.Pattern;
 
 public class URLBuilder {
 
-	public static final String VERSION = "2.1.1";
-	private static final String DOMAIN_REGEX = "^(?:[a-z\\d\\-_]{1,62}\\.){0,125}(?:[a-z\\d](?:\\-(?=\\-*[a-z\\d])|[a-z]|\\d){0,62}\\.)[a-z\\d]{1,63}$";
+    public static final String VERSION = "2.1.1";
+    private static final String DOMAIN_REGEX = "^(?:[a-z\\d\\-_]{1,62}\\.){0,125}(?:[a-z\\d](?:\\-(?=\\-*[a-z\\d])|[a-z]|\\d){0,62}\\.)[a-z\\d]{1,63}$";
 
-	private String domain;
-	private boolean useHttps;
-	private String signKey;
-	private boolean includeLibraryParam;
-	private final ArrayList<Integer> SRCSET_TARGET_WIDTHS = this.targetWidths();
+    private String domain;
+    private boolean useHttps;
+    private String signKey;
+    private boolean includeLibraryParam;
+    private final ArrayList<Integer> SRCSET_TARGET_WIDTHS = this.targetWidths();
 
-	public URLBuilder(String domain, boolean useHttps, String signKey, boolean includeLibraryParam) {
-		Pattern domainPattern = Pattern.compile(DOMAIN_REGEX);
+    public URLBuilder(String domain, boolean useHttps, String signKey, boolean includeLibraryParam) {
+        Pattern domainPattern = Pattern.compile(DOMAIN_REGEX);
 
-		if (domain == null || domain.length() == 0) {
-			throw new IllegalArgumentException("At lease one domain must be passed to URLBuilder");
-		} else if (!domainPattern.matcher(domain).matches()) {
-			throw new IllegalArgumentException("Domain must be passed in as a fully-qualified domain name and should not include a protocol or any path element, i.e. \"example.imgix.net\".");
-		}
+        if (domain == null || domain.length() == 0) {
+            throw new IllegalArgumentException("At lease one domain must be passed to URLBuilder");
+        } else if (!domainPattern.matcher(domain).matches()) {
+            throw new IllegalArgumentException("Domain must be passed in as a fully-qualified domain name and should not include a protocol or any path element, i.e. \"example.imgix.net\".");
+        }
 
-		this.domain = domain;
-		this.useHttps = useHttps;
-		this.signKey = signKey;
-		this.includeLibraryParam = includeLibraryParam;
-	}
+        this.domain = domain;
+        this.useHttps = useHttps;
+        this.signKey = signKey;
+        this.includeLibraryParam = includeLibraryParam;
+    }
 
-	/**
-	 * This single-parameter constructor, accepts a domain string and
-	 * returns a `URLBuilder` with it's `useHttps` member variable set
-	 * to `true` by default.
-	 *
-	 * @param domain - a valid domain string, e.g. `example.imgix.net`
-	 */
-	public URLBuilder(String domain) {
-		this(domain, true);
-	}
+    /**
+     * This single-parameter constructor, accepts a domain string and
+     * returns a `URLBuilder` with it's `useHttps` member variable set
+     * to `true` by default.
+     *
+     * @param domain - a valid domain string, e.g. `example.imgix.net`
+     */
+    public URLBuilder(String domain) {
+        this(domain, true);
+    }
 
-	public URLBuilder(String domain, boolean useHttps) {
-		this(domain, useHttps, "");
-	}
+    public URLBuilder(String domain, boolean useHttps) {
+        this(domain, useHttps, "");
+    }
 
 
-	public URLBuilder(String domain, boolean useHttps, String signKey) {
-		this(domain, useHttps, signKey, true);
-	}
+    public URLBuilder(String domain, boolean useHttps, String signKey) {
+        this(domain, useHttps, signKey, true);
+    }
 
-	public void setUseHttps(boolean useHttps) {
-		this.useHttps = useHttps;
-	}
+    public void setUseHttps(boolean useHttps) {
+        this.useHttps = useHttps;
+    }
 
-	public void setSignKey(String signKey) {
-		this.signKey = signKey;
-	}
+    public void setSignKey(String signKey) {
+        this.signKey = signKey;
+    }
 
-	public String createURL(String path) {
-		return createURL(path, new TreeMap<String, String>());
-	}
+    public String createURL(String path) {
+        return createURL(path, new TreeMap<String, String>());
+    }
 
-	public String createURL(String path, Map<String, String> params) {
-		String scheme = this.useHttps ? "https": "http";
+    public String createURL(String path, Map<String, String> params) {
+        String scheme = this.useHttps ? "https": "http";
 
-		if (this.includeLibraryParam) {
-			params.put("ixlib", "java-" + VERSION);
-		}
+        if (this.includeLibraryParam) {
+            params.put("ixlib", "java-" + VERSION);
+        }
 
-		return new URLHelper(domain, path, scheme, signKey, params).getURL();
-	}
+        return new URLHelper(domain, path, scheme, signKey, params).getURL();
+    }
 
-	public String createSrcSet(String path) {
-		return createSrcSet(path, new TreeMap<String, String>());
-	}
+    public String createSrcSet(String path) {
+        return createSrcSet(path, new TreeMap<String, String>());
+    }
 
-	public String createSrcSet(String path, Map<String, String> params) {
-		String width = params.get("w");
-		String height = params.get("h");
-		String aspectRatio = params.get("ar");
+    public String createSrcSet(String path, Map<String, String> params) {
+        String width = params.get("w");
+        String height = params.get("h");
+        String aspectRatio = params.get("ar");
 
 		/* builds a DPR srcset if either:
 			   a width or
@@ -88,57 +88,57 @@ public class URLBuilder {
 		   are provided, otherwise builds a
 		   srcset of width-pairs
 		 */
-		if (!(width == null || width.isEmpty())
-				|| !((height == null || height.isEmpty())
-				|| (aspectRatio == null || aspectRatio.isEmpty()))) {
-			return createSrcSetDPR(path, params);
-		} else {
-			return createSrcSetPairs(path, params);
-		}
-	}
+        if (!(width == null || width.isEmpty())
+                || !((height == null || height.isEmpty())
+                || (aspectRatio == null || aspectRatio.isEmpty()))) {
+            return createSrcSetDPR(path, params);
+        } else {
+            return createSrcSetPairs(path, params);
+        }
+    }
 
-	private String createSrcSetPairs(String path, Map<String, String> params) {
-		String srcset = "";
+    private String createSrcSetPairs(String path, Map<String, String> params) {
+        String srcset = "";
 
-		for (Integer width: this.SRCSET_TARGET_WIDTHS) {
-			params.put("w", width.toString());
-			srcset += this.createURL(path, params) + " " + width + "w,\n";
-		}
+        for (Integer width: this.SRCSET_TARGET_WIDTHS) {
+            params.put("w", width.toString());
+            srcset += this.createURL(path, params) + " " + width + "w,\n";
+        }
 
-		return srcset.substring(0, srcset.length() - 2);
-	}
+        return srcset.substring(0, srcset.length() - 2);
+    }
 
-	private String createSrcSetDPR(String path, Map<String, String> params) {
-		String srcset = "";
-		int[] srcsetTargetRatios = {1,2,3,4,5};
+    private String createSrcSetDPR(String path, Map<String, String> params) {
+        String srcset = "";
+        int[] srcsetTargetRatios = {1,2,3,4,5};
 
-		for (int ratio: srcsetTargetRatios) {
-			params.put("dpr", Integer.toString(ratio));
-			srcset += this.createURL(path, params) + " " + ratio + "x,\n";
-		}
+        for (int ratio: srcsetTargetRatios) {
+            params.put("dpr", Integer.toString(ratio));
+            srcset += this.createURL(path, params) + " " + ratio + "x,\n";
+        }
 
-		return srcset.substring(0, srcset.length() - 2);
-	}
+        return srcset.substring(0, srcset.length() - 2);
+    }
 
-	private static ArrayList<Integer> targetWidths() {
-		ArrayList<Integer> resolutions = new ArrayList<Integer>();
-		int MAX_SIZE = 8192, roundedPrev;
-		double SRCSET_INCREMENT_PERCENTAGE = 8;
-		double prev = 100;
+    private static ArrayList<Integer> targetWidths() {
+        ArrayList<Integer> resolutions = new ArrayList<Integer>();
+        int MAX_SIZE = 8192, roundedPrev;
+        double SRCSET_INCREMENT_PERCENTAGE = 8;
+        double prev = 100;
 
-		while (prev < MAX_SIZE) {
-			// ensures the added width is even
-			roundedPrev = (int)(2 * Math.round(prev / 2));
-			resolutions.add(roundedPrev);
-			prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100) * 2;
-		}
-		resolutions.add(MAX_SIZE);
+        while (prev < MAX_SIZE) {
+            // ensures the added width is even
+            roundedPrev = (int)(2 * Math.round(prev / 2));
+            resolutions.add(roundedPrev);
+            prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100) * 2;
+        }
+        resolutions.add(MAX_SIZE);
 
-		return resolutions;
-	}
+        return resolutions;
+    }
 
-	public static void main(String[] args) {
-		System.out.println("Hello.");
-	}
+    public static void main(String[] args) {
+        System.out.println("Hello.");
+    }
 
 }

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -22,7 +22,7 @@ public class URLBuilder {
 		if (domain == null || domain.length() == 0) {
 			throw new IllegalArgumentException("At lease one domain must be passed to URLBuilder");
 		} else if (!domainPattern.matcher(domain).matches()) {
-			throw new IllegalArgumentException("Domain must be passed in as fully-qualifies domain name and should not include a protocol or any path element, i.e. \"example.imgix.net\".");
+			throw new IllegalArgumentException("Domain must be passed in as a fully-qualified domain name and should not include a protocol or any path element, i.e. \"example.imgix.net\".");
 		}
 
 		this.domain = domain;

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -22,7 +22,7 @@ public class URLBuilder {
 		if (domain == null || domain.length() == 0) {
 			throw new IllegalArgumentException("At lease one domain must be passed to URLBuilder");
 		} else if (!domainPattern.matcher(domain).matches()) {
-			throw new IllegalArgumentException("Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. \"example.imgix.net\".");
+			throw new IllegalArgumentException("Domain must be passed in as fully-qualifies domain name and should not include a protocol or any path element, i.e. \"example.imgix.net\".");
 		}
 
 		this.domain = domain;
@@ -31,8 +31,15 @@ public class URLBuilder {
 		this.includeLibraryParam = includeLibraryParam;
 	}
 
+	/**
+	 * This single-parameter constructor, accepts a domain string and
+	 * returns a `URLBuilder` with it's `useHttps` member variable set
+	 * to `true` by default.
+	 *
+	 * @param domain - a valid domain string, e.g. `example.imgix.net`
+	 */
 	public URLBuilder(String domain) {
-		this(domain, false);
+		this(domain, true);
 	}
 
 	public URLBuilder(String domain, boolean useHttps) {

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -17,187 +17,187 @@ import java.util.Base64;
 
 public class URLHelper {
 
-	private String domain;
-	private String path;
-	private String scheme;
-	private String signKey;
-	private Map<String, String> parameters;
+    private String domain;
+    private String path;
+    private String scheme;
+    private String signKey;
+    private Map<String, String> parameters;
 
-	public URLHelper(String domain, String path, String scheme, String signKey, Map<String, String> parameters) {
-		this.domain = domain;
-		if (!path.startsWith("/")) {
-			path = "/" + path;
-		}
-		this.path = path;
-		this.scheme = scheme;
-		this.signKey = signKey;
-		this.parameters = new TreeMap<String, String>(parameters);
-	}
+    public URLHelper(String domain, String path, String scheme, String signKey, Map<String, String> parameters) {
+        this.domain = domain;
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        this.path = path;
+        this.scheme = scheme;
+        this.signKey = signKey;
+        this.parameters = new TreeMap<String, String>(parameters);
+    }
 
-	public URLHelper(String domain, String path, String scheme, String signKey) {
-		this(domain, path, scheme, signKey, new TreeMap<String, String>());
-	}
+    public URLHelper(String domain, String path, String scheme, String signKey) {
+        this(domain, path, scheme, signKey, new TreeMap<String, String>());
+    }
 
-	public URLHelper(String domain, String path, String scheme) {
-		this(domain, path, scheme, "");
-	}
+    public URLHelper(String domain, String path, String scheme) {
+        this(domain, path, scheme, "");
+    }
 
-	public URLHelper(String domain, String path) {
-		this(domain, path, "http");
-	}
+    public URLHelper(String domain, String path) {
+        this(domain, path, "http");
+    }
 
-	public void setParameter(String key, String value) {
-		if (value != null && value.length() > 0) {
-			parameters.put(key, value);
-		} else {
-			parameters.remove(key);
-		}
-	}
+    public void setParameter(String key, String value) {
+        if (value != null && value.length() > 0) {
+            parameters.put(key, value);
+        } else {
+            parameters.remove(key);
+        }
+    }
 
-	public void setParameter(String key, Number value) {
-		setParameter(key, String.valueOf(value));
-	}
+    public void setParameter(String key, Number value) {
+        setParameter(key, String.valueOf(value));
+    }
 
-	public void deleteParameter(String key) {
-		setParameter(key, "");
-	}
+    public void deleteParameter(String key) {
+        setParameter(key, "");
+    }
 
-	private String encodeBase64(String str) {
-		String b64EncodedString = null;
+    private String encodeBase64(String str) {
+        String b64EncodedString = null;
 
-		try {
-			byte[] stringBytes = str.getBytes("UTF-8");
-			b64EncodedString = new String(Base64.getEncoder().encode(stringBytes), "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new IllegalArgumentException(e);
-		}
+        try {
+            byte[] stringBytes = str.getBytes("UTF-8");
+            b64EncodedString = new String(Base64.getEncoder().encode(stringBytes), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(e);
+        }
 
-		b64EncodedString = b64EncodedString.replace("=", "");
-		b64EncodedString = b64EncodedString.replace('/', '_');
-		b64EncodedString = b64EncodedString.replace('+', '-');
+        b64EncodedString = b64EncodedString.replace("=", "");
+        b64EncodedString = b64EncodedString.replace('/', '_');
+        b64EncodedString = b64EncodedString.replace('+', '-');
 
-		return b64EncodedString;
-	}
+        return b64EncodedString;
+    }
 
-	public String getURL() {
-		List<String> queryPairs = new LinkedList<String>();
+    public String getURL() {
+        List<String> queryPairs = new LinkedList<String>();
 
-		for (Entry<String, String> entry : parameters.entrySet()) {
-			String k = encodeURIComponent(entry.getKey());
-			String v = entry.getValue();
+        for (Entry<String, String> entry : parameters.entrySet()) {
+            String k = encodeURIComponent(entry.getKey());
+            String v = entry.getValue();
 
-			String encodedValue;
+            String encodedValue;
 
-			if (k.endsWith("64")) {
-				encodedValue = encodeBase64(v);
-			} else {
-				encodedValue = encodeURIComponent(v);
-			}
-			queryPairs.add(k + "=" + encodedValue);
-		}
+            if (k.endsWith("64")) {
+                encodedValue = encodeBase64(v);
+            } else {
+                encodedValue = encodeURIComponent(v);
+            }
+            queryPairs.add(k + "=" + encodedValue);
+        }
 
-		String query = joinList(queryPairs, "&");
+        String query = joinList(queryPairs, "&");
 
-		String decodedPath = URLHelper.decodeURIComponent(path.substring(1));
-		if (decodedPath.startsWith("http://") || decodedPath.startsWith("https://")) {
-			path = "/" + URLHelper.encodeURIComponent(decodedPath);
-		}
+        String decodedPath = URLHelper.decodeURIComponent(path.substring(1));
+        if (decodedPath.startsWith("http://") || decodedPath.startsWith("https://")) {
+            path = "/" + URLHelper.encodeURIComponent(decodedPath);
+        }
 
-		if (signKey != null && signKey.length() > 0) {
-			String delim = query.equals("") ? "" : "?";
-			String toSign = signKey + path + delim + query;
-			String signature = MD5(toSign);
+        if (signKey != null && signKey.length() > 0) {
+            String delim = query.equals("") ? "" : "?";
+            String toSign = signKey + path + delim + query;
+            String signature = MD5(toSign);
 
-			if (query.length() > 0) {
-				query += "&s=" + signature;
-			} else {
-				query = "s=" + signature;
-			}
+            if (query.length() > 0) {
+                query += "&s=" + signature;
+            } else {
+                query = "s=" + signature;
+            }
 
-			return buildURL(scheme, domain, path, query);
-		}
+            return buildURL(scheme, domain, path, query);
+        }
 
-		return buildURL(scheme, domain, path, query);
-	}
+        return buildURL(scheme, domain, path, query);
+    }
 
-	@Override
-	public String toString() {
-		return getURL();
-	}
+    @Override
+    public String toString() {
+        return getURL();
+    }
 
-	///////////// Static
+    ///////////// Static
 
-	private static String buildURL(String scheme, String host, String path, String query) {
-		// do not use URI to build URL since it will do auto-encoding which can break our previous signing
-		String url = String.format("%s://%s%s?%s", scheme, host, path, query);
-		if (url.endsWith("#")) {
-			url = url.substring(0, url.length() - 1);
-		}
+    private static String buildURL(String scheme, String host, String path, String query) {
+        // do not use URI to build URL since it will do auto-encoding which can break our previous signing
+        String url = String.format("%s://%s%s?%s", scheme, host, path, query);
+        if (url.endsWith("#")) {
+            url = url.substring(0, url.length() - 1);
+        }
 
-		if (url.endsWith("?")) {
-			url = url.substring(0, url.length() - 1);
-		}
+        if (url.endsWith("?")) {
+            url = url.substring(0, url.length() - 1);
+        }
 
-		return url;
-	}
+        return url;
+    }
 
-	private static String MD5(String md5) {
-	   try {
-			MessageDigest md = MessageDigest.getInstance("MD5");
-			byte[] array = md.digest(md5.getBytes("UTF-8"));
-			StringBuffer sb = new StringBuffer();
-			for (int i = 0; i < array.length; ++i) {
-			  sb.append(Integer.toHexString((array[i] & 0xFF) | 0x100).substring(1,3));
-		   }
-			return sb.toString();
-		} catch (UnsupportedEncodingException e) {
-		} catch (NoSuchAlgorithmException e) {
-		}
-		return null;
-	}
+    private static String MD5(String md5) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] array = md.digest(md5.getBytes("UTF-8"));
+            StringBuffer sb = new StringBuffer();
+            for (int i = 0; i < array.length; ++i) {
+                sb.append(Integer.toHexString((array[i] & 0xFF) | 0x100).substring(1,3));
+            }
+            return sb.toString();
+        } catch (UnsupportedEncodingException e) {
+        } catch (NoSuchAlgorithmException e) {
+        }
+        return null;
+    }
 
-	private static String joinList(List<String> strings, String separator) {
-		StringBuilder sb = new StringBuilder();
-		String sep = "";
-		for(String s: strings) {
-			sb.append(sep).append(s);
-			sep = separator;
-		}
-		return sb.toString();
-	}
+    private static String joinList(List<String> strings, String separator) {
+        StringBuilder sb = new StringBuilder();
+        String sep = "";
+        for(String s: strings) {
+            sb.append(sep).append(s);
+            sep = separator;
+        }
+        return sb.toString();
+    }
 
-	public static String encodeURIComponent(String s) {
-		String result = null;
+    public static String encodeURIComponent(String s) {
+        String result = null;
 
-		try {
-		  result = URLEncoder.encode(s, "UTF-8")
-							 .replaceAll("\\+", "%20")
-							 .replaceAll("\\%21", "!")
-							 .replaceAll("\\%27", "'")
-							 .replaceAll("\\%28", "(")
-							 .replaceAll("\\%29", ")")
-							 .replaceAll("\\%7E", "~");
-		} catch (UnsupportedEncodingException e) {
-		  result = s;
-		}
+        try {
+            result = URLEncoder.encode(s, "UTF-8")
+                    .replaceAll("\\+", "%20")
+                    .replaceAll("\\%21", "!")
+                    .replaceAll("\\%27", "'")
+                    .replaceAll("\\%28", "(")
+                    .replaceAll("\\%29", ")")
+                    .replaceAll("\\%7E", "~");
+        } catch (UnsupportedEncodingException e) {
+            result = s;
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	public static String decodeURIComponent(String s) {
-		if (s == null) {
-			return null;
-		}
+    public static String decodeURIComponent(String s) {
+        if (s == null) {
+            return null;
+        }
 
-		String result = null;
+        String result = null;
 
-		try {
-			result = URLDecoder.decode(s, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			result = s;
-		}
+        try {
+            result = URLDecoder.decode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            result = s;
+        }
 
-		return result;
-  }
+        return result;
+    }
 
 }

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -19,210 +19,231 @@ import java.net.URISyntaxException;
 @RunWith(JUnit4.class)
 public class TestAll {
 
-	@Rule
-	public ExpectedException exception = ExpectedException.none();
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
-	@Test
-	public void testURLBuilderRaisesExceptionOnNoDomains() {
-		exception.expect(IllegalArgumentException.class);
-		URLBuilder ub = new URLBuilder(new String ());
-	}
+    @Test
+    public void testURLBuilderRaisesExceptionOnNoDomains() {
+        exception.expect(IllegalArgumentException.class);
+        URLBuilder ub = new URLBuilder(new String ());
+    }
 
-	@Test
-	public void testURLBuilderUsesHttpsByDefault() {
-		URLBuilder ub = new URLBuilder("example.imgix.net");
-		assertEquals("https://example.imgix.net/?ixlib=java-2.1.1", ub.createURL(""));
-		// Set `useHttps` to false.
-		ub.setUseHttps(false);
-		assertNotEquals("https://example.imgix.net/?ixlib=java-2.1.1", ub.createURL(""));
-		assertEquals("http://example.imgix.net/?ixlib=java-2.1.1", ub.createURL(""));
-	}
+    @Test
+    public void testURLBuilderUsesHttpsByDefault() {
+        // Test `URLBuilder` uses https by default.
+        // This test uses the single-parameter constructor.
+        // The single parameter constructor is the only constructor
+        // where "default" makes sense. E.g. calling
+        // `URLBuilder("example.imgix.net", true)`
+        // passes `true` to the constructor explicitly.
+        URLBuilder ub = new URLBuilder("example.imgix.net");
+        String expected = "https://example.imgix.net/image/file.png?ixlib=java-" + URLBuilder.VERSION;
+        assertEquals(expected, ub.createURL("image/file.png"));
+    }
 
-	@Test
-	public void testHelperBuildAbsolutePath() {
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "/example/chester.png", "http");
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png");
-	}
+    @Test
+    public void testSetUseHttpsFalse() {
+        // Test `setUseHttps` to `false`.
+        URLBuilder ub = new URLBuilder("example.imgix.net");
+        ub.setUseHttps(false);
+        String expected = "http://example.imgix.net/image/file.png?ixlib=java-" + URLBuilder.VERSION;
+        assertEquals(expected, ub.createURL("image/file.png"));
+    }
 
-	@Test
-	public void testHelperBuildRelativePath() {
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http");
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png");
-	}
+    @Test
+    public void testSetUseHttpsTrue() {
+        // Test `setUseHttps` to `true`.
+        URLBuilder ub = new URLBuilder("example.imgix.net");
+        ub.setUseHttps(true);
+        String expected = "https://example.imgix.net/image/file.png?ixlib=java-" + URLBuilder.VERSION;
+        assertEquals(expected, ub.createURL("image/file.png"));
+    }
 
-	@Test
-	public void testHelperBuildNestedPath() {
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "http://www.somedomain.com/example/chester.png", "http");
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester.png");
-	}
+    @Test
+    public void testHelperBuildAbsolutePath() {
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "/example/chester.png", "http");
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png");
+    }
 
-	@Test
-	public void testHelperBuildAbsolutePathWithParams() {
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "/example/chester.png", "http");
-		uh.setParameter("w", 500);
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500");
-	}
+    @Test
+    public void testHelperBuildRelativePath() {
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http");
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png");
+    }
 
-	@Test
-	public void testHelperBuildRelativePathWithParams() {
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http");
-		uh.setParameter("w", 500);
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500");
-	}
+    @Test
+    public void testHelperBuildNestedPath() {
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "http://www.somedomain.com/example/chester.png", "http");
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester.png");
+    }
 
-	@Test
-	public void testHelperBuildNestedPathWithParams() {
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "http://www.somedomain.com/example/chester.png", "http");
-		uh.setParameter("w", 500);
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester.png?w=500");
-	}
+    @Test
+    public void testHelperBuildAbsolutePathWithParams() {
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "/example/chester.png", "http");
+        uh.setParameter("w", 500);
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500");
+    }
 
-	@Test
-	public void testHelperBuildSignedURLWithHashMapParams() {
+    @Test
+    public void testHelperBuildRelativePathWithParams() {
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http");
+        uh.setParameter("w", 500);
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500");
+    }
 
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("w", "500");
+    @Test
+    public void testHelperBuildNestedPathWithParams() {
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "http://www.somedomain.com/example/chester.png", "http");
+        uh.setParameter("w", 500);
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/http%3A%2F%2Fwww.somedomain.com%2Fexample%2Fchester.png?w=500");
+    }
 
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http", "Q61NvXIy", params);
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500&s=787b9057d5c077fe168b4849737d8a90");
-	}
+    @Test
+    public void testHelperBuildSignedURLWithHashMapParams() {
 
-	@Test
-	public void testHelperBuildSignedURLWithHashSetterParams() {
-		URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http", "Q61NvXIy");
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("w", "500");
 
-		uh.setParameter("w", 500);
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http", "Q61NvXIy", params);
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500&s=787b9057d5c077fe168b4849737d8a90");
+    }
 
-		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500&s=787b9057d5c077fe168b4849737d8a90");
-	}
+    @Test
+    public void testHelperBuildSignedURLWithHashSetterParams() {
+        URLHelper uh = new URLHelper("securejackangers.imgix.net", "example/chester.png", "http", "Q61NvXIy");
 
-	@Test
-	public void testHelperBuildSignedURLWithWebProxyWithNoEncoding() {
-		URLHelper uh = new URLHelper("jackttl2.imgix.net", "http://a.abcnews.com/assets/images/navigation/abc-logo.png?r=20", "http", "JHrM2ezd");
-		assertEquals(uh.getURL(), "http://jackttl2.imgix.net/http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20?s=cf82defe3436a957262d0e64c21e72f9");
-	}
+        uh.setParameter("w", 500);
 
-	@Test
-	public void testHelperBuildSignedURLWithWebProxyWithEncoding() {
-		URLHelper uh = new URLHelper("jackttl2.imgix.net", "http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20", "http", "JHrM2ezd");
-		assertEquals(uh.getURL(), "http://jackttl2.imgix.net/http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20?s=cf82defe3436a957262d0e64c21e72f9");
-	}
+        assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png?w=500&s=787b9057d5c077fe168b4849737d8a90");
+    }
 
-	@Test
-	public void testBuildSignedURLWithWebProxyWithUnencodedInput() {
-		URLHelper uh = new URLHelper("imgix-library-web-proxy-test-source.imgix.net", "https://paulstraw.imgix.net/colon:test/benice.jpg", "https", "qN5VOqaLGQUFzETO");
-		assertEquals(uh.getURL(), "https://imgix-library-web-proxy-test-source.imgix.net/https%3A%2F%2Fpaulstraw.imgix.net%2Fcolon%3Atest%2Fbenice.jpg?s=175a054524d75840735855b9263be591");
-	}
+    @Test
+    public void testHelperBuildSignedURLWithWebProxyWithNoEncoding() {
+        URLHelper uh = new URLHelper("jackttl2.imgix.net", "http://a.abcnews.com/assets/images/navigation/abc-logo.png?r=20", "http", "JHrM2ezd");
+        assertEquals(uh.getURL(), "http://jackttl2.imgix.net/http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20?s=cf82defe3436a957262d0e64c21e72f9");
+    }
 
-	@Test
-	public void testBuilderWithFullyQualifiedURL() {
-		URLBuilder ub = new URLBuilder("my-social-network.imgix.net", true, "FOO123bar", false);
-		assertEquals(ub.createURL("http://avatars.com/john-smith.png"), "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?s=493a52f008c91416351f8b33d4883135");
-	}
+    @Test
+    public void testHelperBuildSignedURLWithWebProxyWithEncoding() {
+        URLHelper uh = new URLHelper("jackttl2.imgix.net", "http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20", "http", "JHrM2ezd");
+        assertEquals(uh.getURL(), "http://jackttl2.imgix.net/http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20?s=cf82defe3436a957262d0e64c21e72f9");
+    }
 
-	@Test
-	public void testBuilderWithFullyQualifiedURLAndParameters() {
-		URLBuilder ub = new URLBuilder("my-social-network.imgix.net", true, "FOO123bar", false);
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("w", "400");
-		params.put("h", "300");
-		assertEquals(ub.createURL("http://avatars.com/john-smith.png", params), "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?h=300&w=400&s=a201fe1a3caef4944dcb40f6ce99e746");
-	}
+    @Test
+    public void testBuildSignedURLWithWebProxyWithUnencodedInput() {
+        URLHelper uh = new URLHelper("imgix-library-web-proxy-test-source.imgix.net", "https://paulstraw.imgix.net/colon:test/benice.jpg", "https", "qN5VOqaLGQUFzETO");
+        assertEquals(uh.getURL(), "https://imgix-library-web-proxy-test-source.imgix.net/https%3A%2F%2Fpaulstraw.imgix.net%2Fcolon%3Atest%2Fbenice.jpg?s=175a054524d75840735855b9263be591");
+    }
 
-	@Test
-	public void testHelperBuildSignedUrlWithIxlibParam() {
-		String[] domains = new String[] { "assets.imgix.net" };
-		URLBuilder ub = new URLBuilder("assets.imgix.net", true, "", true);
-		assertTrue(hasURLParameter(ub.createURL("/users/1.png"), "ixlib"));
+    @Test
+    public void testBuilderWithFullyQualifiedURL() {
+        URLBuilder ub = new URLBuilder("my-social-network.imgix.net", true, "FOO123bar", false);
+        assertEquals(ub.createURL("http://avatars.com/john-smith.png"), "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?s=493a52f008c91416351f8b33d4883135");
+    }
 
-		ub = new URLBuilder("assets.imgix.net", true, "", false);
-		assertFalse(hasURLParameter(ub.createURL("/users/1.png"), "ixlib"));
-	}
+    @Test
+    public void testBuilderWithFullyQualifiedURLAndParameters() {
+        URLBuilder ub = new URLBuilder("my-social-network.imgix.net", true, "FOO123bar", false);
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("w", "400");
+        params.put("h", "300");
+        assertEquals(ub.createURL("http://avatars.com/john-smith.png", params), "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?h=300&w=400&s=a201fe1a3caef4944dcb40f6ce99e746");
+    }
 
-	@Test
-	public void testParamKeysAreEscaped() {
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("hello world", "interesting");
+    @Test
+    public void testHelperBuildSignedUrlWithIxlibParam() {
+        String[] domains = new String[] { "assets.imgix.net" };
+        URLBuilder ub = new URLBuilder("assets.imgix.net", true, "", true);
+        assertTrue(hasURLParameter(ub.createURL("/users/1.png"), "ixlib"));
 
-		URLHelper uh = new URLHelper("demo.imgix.net", "demo.png", "https", null, params);
+        ub = new URLBuilder("assets.imgix.net", true, "", false);
+        assertFalse(hasURLParameter(ub.createURL("/users/1.png"), "ixlib"));
+    }
 
-		assertEquals("https://demo.imgix.net/demo.png?hello%20world=interesting", uh.getURL());
-	}
+    @Test
+    public void testParamKeysAreEscaped() {
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("hello world", "interesting");
 
-	@Test
-	public void testParamValuesAreEscaped() {
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("hello_world", "/foo\"> <script>alert(\"hacked\")</script><");
+        URLHelper uh = new URLHelper("demo.imgix.net", "demo.png", "https", null, params);
 
-		URLHelper uh = new URLHelper("demo.imgix.net", "demo.png", "https", null, params);
+        assertEquals("https://demo.imgix.net/demo.png?hello%20world=interesting", uh.getURL());
+    }
 
-		assertEquals("https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C", uh.getURL());
-	}
+    @Test
+    public void testParamValuesAreEscaped() {
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("hello_world", "/foo\"> <script>alert(\"hacked\")</script><");
 
-	@Test
-	public void testBase64ParamVariantsAreBase64Encoded() {
-		Map<String, String> params = new HashMap<String, String>();
-		params.put("txt64", "I cannøt belîév∑ it wors! 😱");
+        URLHelper uh = new URLHelper("demo.imgix.net", "demo.png", "https", null, params);
 
-		URLHelper uh = new URLHelper("demo.imgix.net", "~text", "https", null, params);
+        assertEquals("https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C", uh.getURL());
+    }
 
-		assertEquals("https://demo.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE", uh.getURL());
-	}
+    @Test
+    public void testBase64ParamVariantsAreBase64Encoded() {
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("txt64", "I cannøt belîév∑ it wors! 😱");
 
-	@Test
-	public void testExtractDomain() {
-		String url = "http://jackangers.imgix.net/chester.png";
-		assertEquals(extractDomain(url), "jackangers.imgix.net");
-	}
+        URLHelper uh = new URLHelper("demo.imgix.net", "~text", "https", null, params);
 
-	@Test
-	public void testEncodeDecode() {
-		String url = "http://a.abcnews.com/assets/images/navigation/abc-logo.png?r=20";
-		String encodedUrl = "http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20";
+        assertEquals("https://demo.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE", uh.getURL());
+    }
 
-		assertEquals(URLHelper.encodeURIComponent(url), encodedUrl);
-		assertEquals(URLHelper.decodeURIComponent(encodedUrl), url);
-		assertEquals(URLHelper.encodeURIComponent(URLHelper.decodeURIComponent(encodedUrl)), encodedUrl);
-	}
+    @Test
+    public void testExtractDomain() {
+        String url = "http://jackangers.imgix.net/chester.png";
+        assertEquals(extractDomain(url), "jackangers.imgix.net");
+    }
 
-	@Test
-	public void testInvalidDomainAppendSlash() {
-		exception.expect(IllegalArgumentException.class);
-		URLBuilder ub = new URLBuilder("test.imgix.net/");
-	}
+    @Test
+    public void testEncodeDecode() {
+        String url = "http://a.abcnews.com/assets/images/navigation/abc-logo.png?r=20";
+        String encodedUrl = "http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20";
 
-	@Test
-	public void testInvalidDomainPrependScheme() {
-		exception.expect(IllegalArgumentException.class);
-		URLBuilder ub = new URLBuilder("https://test.imgix.net");
-	}
+        assertEquals(URLHelper.encodeURIComponent(url), encodedUrl);
+        assertEquals(URLHelper.decodeURIComponent(encodedUrl), url);
+        assertEquals(URLHelper.encodeURIComponent(URLHelper.decodeURIComponent(encodedUrl)), encodedUrl);
+    }
 
-	@Test
-	public void testInvalidDomainAppendDash() {
-		exception.expect(IllegalArgumentException.class);
-		URLBuilder ub = new URLBuilder("test.imgix.net-");
-	}
+    @Test
+    public void testInvalidDomainAppendSlash() {
+        exception.expect(IllegalArgumentException.class);
+        URLBuilder ub = new URLBuilder("test.imgix.net/");
+    }
 
-	private static String extractDomain(String url) {
-		try {
-			URI parsed = new URI(url);
-			String curDomain = parsed.getAuthority();
+    @Test
+    public void testInvalidDomainPrependScheme() {
+        exception.expect(IllegalArgumentException.class);
+        URLBuilder ub = new URLBuilder("https://test.imgix.net");
+    }
 
-			return curDomain;
-		} catch (URISyntaxException e) {
-			e.printStackTrace();
-		}
+    @Test
+    public void testInvalidDomainAppendDash() {
+        exception.expect(IllegalArgumentException.class);
+        URLBuilder ub = new URLBuilder("test.imgix.net-");
+    }
 
-		return "";
-	}
+    private static String extractDomain(String url) {
+        try {
+            URI parsed = new URI(url);
+            String curDomain = parsed.getAuthority();
 
-	private static boolean hasURLParameter(String url, String param) {
-		try {
-			URI parsed = new URI(url);
-			String query = parsed.getQuery();
-			return query != null && query.contains(param);
-		} catch (URISyntaxException e) {
-			return false;
-		}
-	}
+            return curDomain;
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+
+        return "";
+    }
+
+    private static boolean hasURLParameter(String url, String param) {
+        try {
+            URI parsed = new URI(url);
+            String query = parsed.getQuery();
+            return query != null && query.contains(param);
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
 }

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -32,6 +32,10 @@ public class TestAll {
 	public void testURLBuilderUsesHttpsByDefault() {
 		URLBuilder ub = new URLBuilder("example.imgix.net");
 		assertEquals("https://example.imgix.net/?ixlib=java-2.1.1", ub.createURL(""));
+		// Set `useHttps` to false.
+		ub.setUseHttps(false);
+		assertNotEquals("https://example.imgix.net/?ixlib=java-2.1.1", ub.createURL(""));
+		assertEquals("http://example.imgix.net/?ixlib=java-2.1.1", ub.createURL(""));
 	}
 
 	@Test

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -29,6 +29,12 @@ public class TestAll {
 	}
 
 	@Test
+	public void testURLBuilderUsesHttpsByDefault() {
+		URLBuilder ub = new URLBuilder("example.imgix.net");
+		assertEquals("https://example.imgix.net/?ixlib=java-2.1.1", ub.createURL(""));
+	}
+
+	@Test
 	public void testHelperBuildAbsolutePath() {
 		URLHelper uh = new URLHelper("securejackangers.imgix.net", "/example/chester.png", "http");
 		assertEquals(uh.getURL(), "http://securejackangers.imgix.net/example/chester.png");


### PR DESCRIPTION
## feat(https): use https by default

### Description
This PR changes the default behavior of the single-argument
`URLBuilder` constructor. This change ensures that a default
constructed `URLBuilder` has its `useHttps` member variable
set to `true` so that urls are generated for the https scheme.

### Change (Breaking)
__This change in behavior represents a breaking change__. 

### Before 
Prior to this change, users could rely on a default-constructed `URLBuilder`'s
`useHttps` member variable to be `false`. This meant that generated urls
would have their scheme set to "http" by default.

### Now
**Now, `URLBuilder`'s `useHttps` member variable is set to `true`**. This means
that generated urls now have their scheme set to "https".

### Testing
-  three new tests have been added
-  one to test the default constructor (single-parameter)
    constructs an https-url by default (by calling `createUrl`)
  - [x] this new test __does fail__ before the breaking change
  - [x] this new test __does pass__ after this breaking change
- one to test that `setUseHttps` correctly sets `false`
- one to test that `setUseHttps` correctly sets `true`

### Misc
In the [initial commit](https://github.com/imgix/imgix-java/commit/93dacc10ee90083bab1aee8e6e293cd23d40ec1c), IntelliJ tried to sneak in some spelling suggestions.

The suggested change was erroneously pushed with the above commit. IntelliJ was
right in that a change could/should be made.

An extra `a` _does_ improve the grammar of the exception message of which it is now part of.

We also took this opportunity to reformat the code base to indent files with spaces instead of tab characters (for more consistency).