### PR TITLE
feat: prevent push mistakes by updating .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,26 @@
+# Ignore bin directory.
+bin/
+
+# Ignore build directory.
 build/
-*.iml
-.idea/
+
+# Ignore .classpath file.
+.classpath
+
+# Ignore .gradle/ directory.
 /.gradle
+
+# Ignore .iml files (IntelliJ).
+*.iml
+
+# Ignore .idea/ directory (IntelliJ).
+.idea/
+
+# Ignore .java-version file.
+.java-version
+
+# Ignore .settings/ directory (Vscode).
 .settings/
+
+# Ignore .project file.
 .project


### PR DESCRIPTION
This commit updates `.gitignore` to guard against pushing `mistakes/`.

To accommodate more contributors, a few editor specific cases have been
added to `.gitignore`. This way, we can reduce the chances of pushing
things we don't want to and focus on the task at hand. Examples of
these things are build files, `dist/` and `bin/` directories, etc.