### PR TITLE
feat: custom srcsets

### DIFF
--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -220,7 +220,22 @@ public class URLBuilder {
     }
 
     public static ArrayList<Integer> targetWidths() {
-        return targetWidths(MIN_WIDTH, MAX_WIDTH, SRCSET_WIDTH_TOLERANCE);
+        // This default target widths function maintains the "ensure even"
+        // semantics.
+        double begin = MIN_WIDTH, end = MAX_WIDTH;
+
+        ArrayList<Integer> resolutions = new ArrayList<Integer>();
+        while (begin < end) {
+            resolutions.add(makeEven(begin));
+            begin *= 1 + ((double) SRCSET_WIDTH_TOLERANCE / 100) * 2;
+        }
+
+        int lastIndex = resolutions.size() - 1;
+        if (resolutions.get(lastIndex) < end) {
+            resolutions.add(makeEven(end));
+        }
+
+        return resolutions;
     }
 
     /**

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -189,14 +189,6 @@ public class URLBuilder {
         }
     }
 
-    public String createSrcSet(String path, Map<String, String> params, Integer[] targets) {
-        if (isDpr(params)) {
-            return createSrcSetDPR(path, params, targets, false);
-        } else {
-            return createSrcSetPairs(path, params, targets);
-        }
-    }
-
     private String createSrcSetPairs(String path, Map<String, String> params) {
         return createSrcSetPairs(path, params, SRCSET_TARGET_WIDTHS);
     }
@@ -217,11 +209,6 @@ public class URLBuilder {
     }
 
     private String createSrcSetDPR(String path, Map<String, String> params, boolean disableVariableQuality) {
-        return createSrcSetDPR(path, params, DPR_QUALITIES, disableVariableQuality);
-    }
-
-    private String createSrcSetDPR(String path, Map<String, String> params, Integer[] qualities, boolean disableVariableQuality) {
-        assert qualities.length == 5;
         StringBuilder srcset = new StringBuilder();
         Map<String, String> srcsetParams = new HashMap<String, String>(params);
 
@@ -231,7 +218,7 @@ public class URLBuilder {
             srcsetParams.put("dpr", Integer.toString(ratio));
 
             if (!disableVariableQuality && !has_quality) {
-                srcsetParams.put("q", qualities[ratio - 1].toString());
+                srcsetParams.put("q", DPR_QUALITIES[ratio - 1].toString());
             }
             srcset.append(this.createURL(path, srcsetParams)).append(" ").append(ratio).append("x,\n");
         }

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -52,7 +52,6 @@ public class URLBuilder {
         this(domain, useHttps, "");
     }
 
-
     public URLBuilder(String domain, boolean useHttps, String signKey) {
         this(domain, useHttps, signKey, true);
     }
@@ -261,7 +260,7 @@ public class URLBuilder {
      * @param tol - tolerable amount of width value variation
      * @return array list of _even_ image width values
      */
-    public static ArrayList<Integer> targetWidths(double begin, double end, double tol) {
+    public static ArrayList<Integer> targetWidths(int begin, int end, int tol) {
         if (notCustom(begin, end, tol)) {
             return targetWidths();
         }
@@ -272,13 +271,13 @@ public class URLBuilder {
 
         ArrayList<Integer> resolutions = new ArrayList<Integer>();
         while (begin < end && begin < MAX_WIDTH) {
-            resolutions.add(makeEven(begin));
-            begin *= 1 + (tol/ 100) * 2;
+            resolutions.add(begin);
+            begin *= 1 + ((double) tol / 100) * 2;
         }
 
         int lastIndex = resolutions.size() - 1;
         if (resolutions.get(lastIndex) < end) {
-            resolutions.add(makeEven(end));
+            resolutions.add(end);
         }
 
         return resolutions;
@@ -301,14 +300,14 @@ public class URLBuilder {
     }
 
     private static boolean notCustom(double begin, double end, double tol) {
-        boolean notDefaultBegin = (begin != MIN_WIDTH);
-        boolean notDefaultEnd = (end != MAX_WIDTH);
-        boolean notDefaultTol = (tol != SRCSET_WIDTH_TOLERANCE);
+        boolean defaultBegin = (begin == MIN_WIDTH);
+        boolean defaultEnd = (end == MAX_WIDTH);
+        boolean defaultTol = (tol == SRCSET_WIDTH_TOLERANCE);
 
-        // If `begin`, `end`, or `tol` differ from their default
-        // values, then together they _do not_ represent a custom
+        // If `begin`, `end`, or `tol` differ from their
+        // default values, then together they _do not_ represent a custom
         // target widths range and this function returns true.
-        return notDefaultBegin || notDefaultEnd || notDefaultTol;
+        return defaultBegin && defaultEnd && defaultTol;
     }
 
     private static int makeEven(double value) {

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -94,11 +94,8 @@ public class URLBuilder {
      * @return srcset attribute string
      */
     public String createSrcSet(String path, Map<String, String> params) {
-        if (isDpr(params)) {
-            return createSrcSetDPR(path, params);
-        } else {
-            return createSrcSetPairs(path, params);
-        }
+        return createSrcSet(path, params, MIN_WIDTH, MAX_WIDTH, SRCSET_WIDTH_TOLERANCE, false);
+
     }
 
     public String createSrcSet(String path) {
@@ -117,7 +114,7 @@ public class URLBuilder {
      * @return srcset attribute string
      */
     public String createSrcSet(String path, Map<String, String> params, int tol) {
-        return createSrcSet(path, params, MIN_WIDTH, MAX_WIDTH, tol);
+        return createSrcSet(path, params, MIN_WIDTH, MAX_WIDTH, tol, false);
     }
 
     /**
@@ -135,7 +132,7 @@ public class URLBuilder {
      * @return srcset attribute string
      */
     public String createSrcSet(String path, Map<String, String> params, int begin, int end) {
-        return createSrcSet(path, params, begin, end, SRCSET_WIDTH_TOLERANCE);
+        return createSrcSet(path, params, begin, end, SRCSET_WIDTH_TOLERANCE, false);
     }
 
     /**
@@ -155,8 +152,7 @@ public class URLBuilder {
      * @return srcset attribute string
      */
     public String createSrcSet(String path, Map<String, String> params, int begin, int end, int tol) {
-        ArrayList<Integer> targets = targetWidths(begin, end, tol);
-        return createSrcSetPairs(path, params, targets);
+        return createSrcSet(path, params, begin, end, tol, false);
     }
 
     /**
@@ -177,7 +173,16 @@ public class URLBuilder {
      * @return srcset attribute string
      */
     public String createSrcSet(String path, Map<String, String> params, boolean disableVariableQuality) {
-        return createSrcSetDPR(path, params, disableVariableQuality);
+        return createSrcSet(path, params, MIN_WIDTH, MAX_WIDTH, SRCSET_WIDTH_TOLERANCE, disableVariableQuality);
+    }
+
+    public String createSrcSet(String path, Map<String, String> params, int begin, int end, int tol, boolean disableVariableQuality) {
+        if (isDpr(params)) {
+            return createSrcSetDPR(path, params, disableVariableQuality);
+        } else {
+            ArrayList<Integer> targets = targetWidths(begin, end, tol);
+            return createSrcSetPairs(path, params, targets);
+        }
     }
 
     private String createSrcSetPairs(String path, Map<String, String> params) {

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -266,7 +266,7 @@ public class URLBuilder {
         }
 
         if (begin == end) {
-            return new ArrayList<Integer>(makeEven(begin));
+            return new ArrayList<Integer>(begin);
         }
 
         ArrayList<Integer> resolutions = new ArrayList<Integer>();

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -266,20 +266,7 @@ public class URLBuilder {
     }
 
     public static ArrayList<Integer> targetWidths() {
-        double begin = MIN_WIDTH, end = MAX_WIDTH;
-
-        ArrayList<Integer> resolutions = new ArrayList<Integer>();
-        while (begin < end) {
-            resolutions.add((int) Math.round(begin));
-            begin *= 1 + ((double) SRCSET_WIDTH_TOLERANCE / 100) * 2;
-        }
-
-        int lastIndex = resolutions.size() - 1;
-        if (resolutions.get(lastIndex) < end) {
-            resolutions.add((int) end);
-        }
-
-        return resolutions;
+        return new ArrayList<Integer>(Arrays.asList(SRCSET_TARGET_WIDTHS));
     }
 
     /**

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -22,6 +22,7 @@ public class URLBuilder {
             328, 380, 441, 512, 594, 689, 799, 927,
             1075, 1247, 1446, 1678, 1946, 2257, 2619,
             3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
+    private static final ArrayList<Integer> sss = new ArrayList<Integer>();
     private static final int SRCSET_WIDTH_TOLERANCE = 8;
     private static final int MIN_WIDTH = 100;
     private static final int MAX_WIDTH = 8192;
@@ -187,6 +188,11 @@ public class URLBuilder {
             Integer[] targets = targetWidths(begin, end, tol).toArray(new Integer[0]);
             return createSrcSetPairs(path, params, targets);
         }
+    }
+
+
+    public String createSrcSet(String path, HashMap<String, String> params, Integer[] targets) {
+        return createSrcSetPairs(path, params, targets);
     }
 
     private String createSrcSetPairs(String path, Map<String, String> params) {

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -234,9 +234,11 @@ public class URLBuilder {
      * then the list begins where it ends.
      *
      * When the `while` loop terminates, `begin` is greater than `end`
-     * (where `end` <= `MAX_WIDTH`). This means that the most recently
-     * appended value may, or may not, be the `end` value. To be
-     * inclusive of the ending value, we check for this case and the
+     * (where `end` less than or equal to `MAX_WIDTH`). This means that
+     * the most recently appended value may, or may not, be the `end`
+     * value.
+     *
+     * To be inclusive of the ending value, we check for this case and the
      * value is added if necessary.
      *
      * @param begin - beginning image width value

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -164,12 +164,10 @@ public class TestAll {
     @Test
     public void testTargetWidths() {
        ArrayList<Integer> actual = URLBuilder.targetWidths(100, 8192, 8);
-       int[] targetWidths = {
-               100, 116, 134, 156, 182, 210, 244,
-               282, 328, 380, 442, 512, 594, 688,
-               798, 926, 1074, 1246, 1446, 1678, 1946,
-               2258, 2618, 3038, 3524, 4088, 4742, 5500,
-               6380, 7400, 8192};
+       int[] targetWidths = {100, 116, 135, 156, 181, 210, 244, 283,
+               328, 380, 441, 512, 594, 689, 799, 927,
+               1075, 1247, 1446, 1678, 1946, 2257, 2619,
+               3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
        for (int i = 0; i < targetWidths.length; ++i) {
            assertEquals(targetWidths[i], (int) actual.get(i));
        }

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.*;
 import com.imgix.URLBuilder;
 import com.imgix.URLHelper;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -158,6 +159,20 @@ public class TestAll {
 
         ub = new URLBuilder("assets.imgix.net", true, "", false);
         assertFalse(hasURLParameter(ub.createURL("/users/1.png"), "ixlib"));
+    }
+
+    @Test
+    public void testTargetWidths() {
+       ArrayList<Integer> actual = URLBuilder.targetWidths(100, 8192, 8);
+       int[] targetWidths = {
+               100, 116, 134, 156, 182, 210, 244,
+               282, 328, 380, 442, 512, 594, 688,
+               798, 926, 1074, 1246, 1446, 1678, 1946,
+               2258, 2618, 3038, 3524, 4088, 4742, 5500,
+               6380, 7400, 8192};
+       for (int i = 0; i < targetWidths.length; ++i) {
+           assertEquals(targetWidths[i], (int) actual.get(i));
+       }
     }
 
     @Test

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -631,23 +631,6 @@ public class TestSrcSet {
     }
 
     @Test
-    public void testCreateSrcSetQualities() {
-        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
-        HashMap<String, String>  params = new HashMap<String, String>();
-        params.put("h", "100");
-        params.put("ar", "4:3");
-
-        String actual = ub.createSrcSet("image.png", params, new Integer[] {1024, 512, 128, 64, 32});
-        String expected = "http://test.imgix.net/image.png?ar=4%3A3&dpr=1&h=100&q=1024 1x,\n" +
-                "http://test.imgix.net/image.png?ar=4%3A3&dpr=2&h=100&q=512 2x,\n" +
-                "http://test.imgix.net/image.png?ar=4%3A3&dpr=3&h=100&q=128 3x,\n" +
-                "http://test.imgix.net/image.png?ar=4%3A3&dpr=4&h=100&q=64 4x,\n" +
-                "http://test.imgix.net/image.png?ar=4%3A3&dpr=5&h=100&q=32 5x";
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
     public void testCreateSrcSetPairsBeginEnd() {
         URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
         HashMap<String, String>  params = new HashMap<String, String>();
@@ -703,21 +686,6 @@ public class TestSrcSet {
         HashMap<String, String>  params = new HashMap<String, String>();
         String actual = ub.createSrcSet("image.png", params, 640, 640);
         String expected = "http://test.imgix.net/image.png?w=640 640w";
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testCreateSrcSetWidthTargets() {
-        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
-        HashMap<String, String>  params = new HashMap<String, String>();
-        String actual = ub.createSrcSet("image.png", params, new Integer[] {100, 200, 300, 400, 500, 600});
-        String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
-                "http://test.imgix.net/image.png?w=200 200w,\n" +
-                "http://test.imgix.net/image.png?w=300 300w,\n" +
-                "http://test.imgix.net/image.png?w=400 400w,\n" +
-                "http://test.imgix.net/image.png?w=500 500w,\n" +
-                "http://test.imgix.net/image.png?w=600 600w";
 
         assertEquals(expected, actual);
     }

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -71,10 +71,10 @@ public class TestSrcSet {
 
     @Test
     public void testNoParametersGeneratesCorrectWidths() {
-        int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+        int[] targetWidths = {100, 116, 135, 156, 181, 210, 244, 283,
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1446, 1678, 1946, 2257, 2619,
+                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
         String generatedWidth;
         int index = 0;
@@ -211,10 +211,10 @@ public class TestSrcSet {
 
     @Test
     public void testHeightGeneratesCorrectWidths() {
-        int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+        int[] targetWidths = {100, 116, 135, 156, 181, 210, 244, 283,
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1446, 1678, 1946, 2257, 2619,
+                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
         String generatedWidth;
         int index = 0;
@@ -361,10 +361,10 @@ public class TestSrcSet {
 
     @Test
     public void testAspectRatioGeneratesCorrectWidths() {
-        int[] targetWidths = {100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192};
+        int[] targetWidths = {100, 116, 135, 156, 181, 210, 244, 283,
+                328, 380, 441, 512, 594, 689, 799, 927,
+                1075, 1247, 1446, 1678, 1946, 2257, 2619,
+                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
         String generatedWidth;
         int index = 0;
@@ -567,6 +567,8 @@ public class TestSrcSet {
         URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
         HashMap<String, String>  params = new HashMap<String, String>();
         params.put("w", "320");
+        // Ensure calling 2-param `createSrcSet` yields same results as
+        // calling 3-param `createSrcSet`.
         String actualWith2Param = ub.createSrcSet("image.png", params);
         String actualWith3Param = ub.createSrcSet("image.png", params, false);
         String expected = "http://test.imgix.net/image.png?dpr=1&q=75&w=320 1x,\n" +
@@ -600,15 +602,14 @@ public class TestSrcSet {
         HashMap<String, String>  params = new HashMap<String, String>();
         String actual = ub.createSrcSet("image.png", params, 100, 380);
         String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
-                "http://test.imgix.net/image.png?w=115 115w,\n" +
-                "http://test.imgix.net/image.png?w=133 133w,\n" +
-                "http://test.imgix.net/image.png?w=154 154w,\n" +
-                "http://test.imgix.net/image.png?w=178 178w,\n" +
-                "http://test.imgix.net/image.png?w=206 206w,\n" + 
-                "http://test.imgix.net/image.png?w=238 238w,\n" +
-                "http://test.imgix.net/image.png?w=276 276w,\n" +
-                "http://test.imgix.net/image.png?w=320 320w,\n" +
-                "http://test.imgix.net/image.png?w=371 371w,\n" + 
+                "http://test.imgix.net/image.png?w=116 116w,\n" +
+                "http://test.imgix.net/image.png?w=135 135w,\n" +
+                "http://test.imgix.net/image.png?w=156 156w,\n" +
+                "http://test.imgix.net/image.png?w=181 181w,\n" +
+                "http://test.imgix.net/image.png?w=210 210w,\n" +
+                "http://test.imgix.net/image.png?w=244 244w,\n" +
+                "http://test.imgix.net/image.png?w=283 283w,\n" +
+                "http://test.imgix.net/image.png?w=328 328w,\n" +
                 "http://test.imgix.net/image.png?w=380 380w";
 
         assertEquals(expected, actual);

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -561,4 +561,87 @@ public class TestSrcSet {
             assert(src.contains(String.format("dpr=%s", i+1)));
         }
     }
+
+    @Test
+    public void testDisableVariableQualityOffByDefault() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        params.put("w", "320");
+        String actualWith2Param = ub.createSrcSet("image.png", params);
+        String actualWith3Param = ub.createSrcSet("image.png", params, false);
+        String expected = "http://test.imgix.net/image.png?dpr=1&q=75&w=320 1x,\n" +
+                "http://test.imgix.net/image.png?dpr=2&q=50&w=320 2x,\n" +
+                "http://test.imgix.net/image.png?dpr=3&q=35&w=320 3x,\n" +
+                "http://test.imgix.net/image.png?dpr=4&q=23&w=320 4x,\n" +
+                "http://test.imgix.net/image.png?dpr=5&q=20&w=320 5x";
+
+        assertEquals(expected, actualWith2Param);
+        assertEquals(expected, actualWith3Param);
+    }
+
+    @Test
+    public void testDisableVariableQuality() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        params.put("w", "320");
+        String actual = ub.createSrcSet("image.png", params, true);
+        String expected = "http://test.imgix.net/image.png?dpr=1&w=320 1x,\n" +
+                "http://test.imgix.net/image.png?dpr=2&w=320 2x,\n" +
+                "http://test.imgix.net/image.png?dpr=3&w=320 3x,\n" +
+                "http://test.imgix.net/image.png?dpr=4&w=320 4x,\n" +
+                "http://test.imgix.net/image.png?dpr=5&w=320 5x";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetPairsBeginEnd() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, 100, 380);
+        String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
+                "http://test.imgix.net/image.png?w=115 115w,\n" +
+                "http://test.imgix.net/image.png?w=133 133w,\n" +
+                "http://test.imgix.net/image.png?w=154 154w,\n" +
+                "http://test.imgix.net/image.png?w=178 178w,\n" +
+                "http://test.imgix.net/image.png?w=206 206w,\n" + 
+                "http://test.imgix.net/image.png?w=238 238w,\n" +
+                "http://test.imgix.net/image.png?w=276 276w,\n" +
+                "http://test.imgix.net/image.png?w=320 320w,\n" +
+                "http://test.imgix.net/image.png?w=371 371w,\n" + 
+                "http://test.imgix.net/image.png?w=380 380w";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetPairsBeginEndTol() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, 100, 108, 1);
+        String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
+                "http://test.imgix.net/image.png?w=102 102w,\n" +
+                "http://test.imgix.net/image.png?w=104 104w,\n" +
+                "http://test.imgix.net/image.png?w=106 106w,\n" +
+                "http://test.imgix.net/image.png?w=108 108w";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetTol() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, 50);
+        String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
+                "http://test.imgix.net/image.png?w=200 200w,\n" +
+                "http://test.imgix.net/image.png?w=400 400w,\n" +
+                "http://test.imgix.net/image.png?w=800 800w,\n" +
+                "http://test.imgix.net/image.png?w=1600 1600w,\n" +
+                "http://test.imgix.net/image.png?w=3200 3200w,\n" +
+                "http://test.imgix.net/image.png?w=6400 6400w,\n" +
+                "http://test.imgix.net/image.png?w=8192 8192w";
+
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -689,4 +689,19 @@ public class TestSrcSet {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void testCreateSrcSetWidthTargets() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, new Integer[] {100, 200, 300, 400, 500, 600});
+        String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
+                "http://test.imgix.net/image.png?w=200 200w,\n" +
+                "http://test.imgix.net/image.png?w=300 300w,\n" +
+                "http://test.imgix.net/image.png?w=400 400w,\n" +
+                "http://test.imgix.net/image.png?w=500 500w,\n" +
+                "http://test.imgix.net/image.png?w=600 600w";
+
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -597,6 +597,40 @@ public class TestSrcSet {
     }
 
     @Test
+    public void testDisableVariableQualityWithQuality() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        params.put("w", "320");
+        params.put("q", "99");
+        String actual = ub.createSrcSet("image.png", params, true);
+        String expected = "http://test.imgix.net/image.png?dpr=1&q=99&w=320 1x,\n" +
+                "http://test.imgix.net/image.png?dpr=2&q=99&w=320 2x,\n" +
+                "http://test.imgix.net/image.png?dpr=3&q=99&w=320 3x,\n" +
+                "http://test.imgix.net/image.png?dpr=4&q=99&w=320 4x,\n" +
+                "http://test.imgix.net/image.png?dpr=5&q=99&w=320 5x";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetQandVariableQualityEnabled() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        params.put("ar", "4:3");
+        params.put("h", "100");
+        params.put("q", "99");
+
+        String actual = ub.createSrcSet("image.png", params);
+        String expected = "http://test.imgix.net/image.png?ar=4%3A3&dpr=1&h=100&q=99 1x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=2&h=100&q=99 2x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=3&h=100&q=99 3x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=4&h=100&q=99 4x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=5&h=100&q=99 5x";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testCreateSrcSetPairsBeginEnd() {
         URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
         HashMap<String, String>  params = new HashMap<String, String>();
@@ -642,6 +676,16 @@ public class TestSrcSet {
                 "http://test.imgix.net/image.png?w=3200 3200w,\n" +
                 "http://test.imgix.net/image.png?w=6400 6400w,\n" +
                 "http://test.imgix.net/image.png?w=8192 8192w";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetBeginEqualsEnd() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, 640, 640);
+        String expected = "http://test.imgix.net/image.png?w=640 640w";
 
         assertEquals(expected, actual);
     }

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -631,6 +631,23 @@ public class TestSrcSet {
     }
 
     @Test
+    public void testCreateSrcSetQualities() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        params.put("h", "100");
+        params.put("ar", "4:3");
+
+        String actual = ub.createSrcSet("image.png", params, new Integer[] {1024, 512, 128, 64, 32});
+        String expected = "http://test.imgix.net/image.png?ar=4%3A3&dpr=1&h=100&q=1024 1x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=2&h=100&q=512 2x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=3&h=100&q=128 3x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=4&h=100&q=64 4x,\n" +
+                "http://test.imgix.net/image.png?ar=4%3A3&dpr=5&h=100&q=32 5x";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testCreateSrcSetPairsBeginEnd() {
         URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
         HashMap<String, String>  params = new HashMap<String, String>();
@@ -686,6 +703,21 @@ public class TestSrcSet {
         HashMap<String, String>  params = new HashMap<String, String>();
         String actual = ub.createSrcSet("image.png", params, 640, 640);
         String expected = "http://test.imgix.net/image.png?w=640 640w";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetWidthTargets() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, new Integer[] {100, 200, 300, 400, 500, 600});
+        String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
+                "http://test.imgix.net/image.png?w=200 200w,\n" +
+                "http://test.imgix.net/image.png?w=300 300w,\n" +
+                "http://test.imgix.net/image.png?w=400 400w,\n" +
+                "http://test.imgix.net/image.png?w=500 500w,\n" +
+                "http://test.imgix.net/image.png?w=600 600w";
 
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
The purpose of this PR is to implement custom source set functionality.
It does so by extending and overloading `createSrcSet`.

`targetWidths` functionality is now public in anticipation of things to
come as well as to expose more functionality.

The `ensureEven` requirement was removed from this PR/feature as
it has been removed from the other SDK as well. In this case, it never
made it into the feature (good).

The removal of custom qualities commit, afd8586, should serve as a
starting point for if/when that feature does make it into the sdk.

For example on how to use the new functionality see the tests located
at `src/test/java/com/imgix/test/TestSrcSet.java` lines 566 through 706.