### PR TITLE
docs: remove dead comment

### DIFF
--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -164,9 +164,6 @@ public class URLBuilder {
      * Create a srcset given a `path`, map of `params`, and the
      * `disableVariableQuality` flag.
      *
-     * This function delegates directly to `createSrcSetDpr` to
-     * create a dpr based srcset with variable image quality output.
-     *
      * If `disableVariableQuality` is `false` then variable output
      * is turned _on_. If `disableVariableQuality` is `true` then
      * variable quality output is turned _off_.


### PR DESCRIPTION
The purpose of this PR is to remove a dead/stale comment;
in the prior implementation it was relevant, however, within
the current context it is no longer relevant/correct.