### PR TITLE
fix: convert tol to float

### DIFF
--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -23,7 +23,7 @@ public class URLBuilder {
             1075, 1247, 1446, 1678, 1946, 2257, 2619,
             3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
 
-    private static final int SRCSET_WIDTH_TOLERANCE = 8;
+    private static final double SRCSET_WIDTH_TOLERANCE = 0.08;
     private static final int MIN_WIDTH = 100;
     private static final int MAX_WIDTH = 8192;
     private static final Integer[] DPR_QUALITIES = {75, 50, 35, 23, 20};
@@ -118,7 +118,7 @@ public class URLBuilder {
      * @param tol - tolerable amount of width value variation
      * @return srcset attribute string
      */
-    public String createSrcSet(String path, Map<String, String> params, int tol) {
+    public String createSrcSet(String path, Map<String, String> params, double tol) {
         return createSrcSet(path, params, MIN_WIDTH, MAX_WIDTH, tol, false);
     }
 
@@ -153,10 +153,10 @@ public class URLBuilder {
      * @param params - map of query parameters
      * @param begin - beginning image width value
      * @param end - ending image width value
-     * @param tol - tolerable amount of width value variation
+     * @param tol - tolerable amount of width value variation, from 0.01 to 1.0
      * @return srcset attribute string
      */
-    public String createSrcSet(String path, Map<String, String> params, int begin, int end, int tol) {
+    public String createSrcSet(String path, Map<String, String> params, int begin, int end, double tol) {
         return createSrcSet(path, params, begin, end, tol, false);
     }
 
@@ -178,7 +178,7 @@ public class URLBuilder {
         return createSrcSet(path, params, MIN_WIDTH, MAX_WIDTH, SRCSET_WIDTH_TOLERANCE, disableVariableQuality);
     }
 
-    public String createSrcSet(String path, Map<String, String> params, int begin, int end, int tol, boolean disableVariableQuality) {
+    public String createSrcSet(String path, Map<String, String> params, int begin, int end, double tol, boolean disableVariableQuality) {
         if (isDpr(params)) {
             return createSrcSetDPR(path, params, disableVariableQuality);
         } else {
@@ -248,10 +248,10 @@ public class URLBuilder {
      *
      * @param begin - beginning image width value
      * @param end - ending image width value
-     * @param tol - tolerable amount of width value variation
+     * @param tol - tolerable amount of width value variation, from 0.01 to 1.0
      * @return array list of image width values
      */
-    public static ArrayList<Integer> targetWidths(int begin, int end, int tol) {
+    public static ArrayList<Integer> targetWidths(int begin, int end, double tol) {
         return computeTargetWidths(begin, end, tol);
     }
 
@@ -287,7 +287,7 @@ public class URLBuilder {
             // Round values so that the resulting `int` is truer
             // to expectations (i.e. 115.99999 --> 116).
             resolutions.add((int) Math.round(begin));
-            begin *= 1 + (tol / 100) * 2;
+            begin *= 1 + tol * 2;
         }
 
         int lastIndex = resolutions.size() - 1;

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -163,7 +163,7 @@ public class TestAll {
 
     @Test
     public void testTargetWidths() {
-       ArrayList<Integer> actual = URLBuilder.targetWidths(100, 8192, 8);
+       ArrayList<Integer> actual = URLBuilder.targetWidths(100, 8192, 0.08);
        int[] targetWidths = {100, 116, 135, 156, 181, 210, 244, 283,
                328, 380, 441, 512, 594, 689, 799, 927,
                1075, 1247, 1446, 1678, 1946, 2257, 2619,

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -653,7 +653,7 @@ public class TestSrcSet {
     public void testCreateSrcSetPairsBeginEndTol() {
         URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
         HashMap<String, String>  params = new HashMap<String, String>();
-        String actual = ub.createSrcSet("image.png", params, 100, 108, 1);
+        String actual = ub.createSrcSet("image.png", params, 100, 108, 0.01);
         String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
                 "http://test.imgix.net/image.png?w=102 102w,\n" +
                 "http://test.imgix.net/image.png?w=104 104w,\n" +
@@ -667,7 +667,7 @@ public class TestSrcSet {
     public void testCreateSrcSetTol() {
         URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
         HashMap<String, String>  params = new HashMap<String, String>();
-        String actual = ub.createSrcSet("image.png", params, 50);
+        String actual = ub.createSrcSet("image.png", params, 0.50);
         String expected = "http://test.imgix.net/image.png?w=100 100w,\n" +
                 "http://test.imgix.net/image.png?w=200 200w,\n" +
                 "http://test.imgix.net/image.png?w=400 400w,\n" +


### PR DESCRIPTION
Prior to this PR, width `tol`erance was expected to be of type `int`
and within the range of `[1, 100]` or "one to one hundred percent."
Now, `tol` is expected to be a `doublet` in the range `[0.01, 1.0]` which
also represents "one to one hundred percent."

We have done this for consistency purposes, i.e. [imgix-core-js](https://github.com/imgix/imgix-core-js/blob/2c9d97a7ab54c7a8fec378732bdcb855cef41907/src/imgix-core-js.js#L25) uses
floating point values. Since `imgix-core-js` was impl'd first, we defer
to this tried/tested interface. This way, this feature is standard
and consistent kit-wide.