### PR TITLE
feat: validate srcset ranges

### DIFF
--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -149,6 +149,9 @@ public class URLBuilder {
      * on the specified values. The specified `tol` determines the tolerable
      * amount of width value variation.
      *
+     * If any value `begin`, `end`, or `tol` is invalid, then an empty
+     * srcset attribute string will be returned.
+     *
      * @param path - path to the image, i.e. "image/file.png"
      * @param params - map of query parameters
      * @param begin - beginning image width value
@@ -198,6 +201,12 @@ public class URLBuilder {
 
     private String createSrcSetPairs(String path, Map<String, String> params, Integer[] widths) {
         StringBuilder srcset = new StringBuilder();
+
+        // If the array of widths is not valid, return an empty string
+        // to indicate an error has occurred.
+        if (!Validate.isValidWidths(widths)) {
+            return "";
+        }
 
         for (Integer width: widths) {
             params.put("w", width.toString());
@@ -270,8 +279,17 @@ public class URLBuilder {
      * of `targetWidths`. Meaning, `begin`, `end`, and `tol` are
      * to be whole integers, but computation requires `double`s. This
      * function hides this detail from callers.
+     *
+     * The inputs are lightly validated. If neither `tol` nor `begin`
+     * _and_ `end` are valid, return an empty list to indicate the
+     * error state (without throwing an exception).
      */
     private static ArrayList<Integer> computeTargetWidths(double begin, double end, double tol) {
+        boolean hasInvalidRange = !Validate.isValidTolerance(tol) || !Validate.isValidWidthRange(begin, end);
+        if (hasInvalidRange) {
+            return new ArrayList<Integer>();
+        }
+
         if (notCustom(begin, end, tol)) {
             return new ArrayList<Integer>(Arrays.asList(SRCSET_TARGET_WIDTHS));
         }

--- a/src/main/java/com/imgix/Validate.java
+++ b/src/main/java/com/imgix/Validate.java
@@ -1,0 +1,53 @@
+package com.imgix;
+
+public class Validate {
+    /**
+     * Validates the width range specified by `begin` and `end`.
+     *
+     * A width range is valid if `begin` is less than or equal to
+     * `end` _and_ if `begin` is greater than zero.
+     *
+     * The maximum value for `end` is generally 8192. However, this
+     * is only the general case. In the future, values larger than
+     * 8192 will become valid.
+     *
+     * @param begin beginning or minimum width value
+     * @param end ending or maximum width value
+     * @return true if the width range is valid, otherwise false
+     */
+    public static boolean isValidWidthRange(double begin, double end) {
+        return (begin <= end) && (begin > 0);
+    }
+
+    /**
+     * Validate the width tolerance specified by `tol`.
+     *
+     * A width `tol`erance is valid if it is greater than or equal to
+     * `0.01` (one percent).
+     *
+     * The upper limit of `tol` is not checked. Generally, this value
+     * should range between [0.01, 1.0] or from one percent to one
+     * hundred percent.
+     *
+     * In the case where a value larger than `1.0` is passed to
+     * `targetWidths`, say `100000`, then one of two "smallest possible
+     * srcsets will be generated (depending on `begin` and `end`)––either
+     * `[begin, end]` or `[begin]` (when `begin == end`).
+     *
+     * @param tol width tolerance to be validated
+     * @return true if `tol` is greater than `0.01`, otherwise false.
+     */
+    public static boolean isValidTolerance(double tol) {
+        return tol >= 0.01;
+    }
+
+    /**
+     * Validate `widths` array to ensure it is _not_ empty.
+     *
+     * @param widths array of integer width values
+     * @return true if `widths` is non-empty, otherwise false
+     */
+    public static boolean isValidWidths(Integer[] widths) {
+        return widths.length > 0;
+    }
+}

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -704,4 +704,38 @@ public class TestSrcSet {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void testCreateSrcSetInvalidTol() {
+        // Test a negative, invalid, width `tol` results in an empty
+        // srcset string.
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, -0.01);
+        String expected = "";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetInvalidBegin() {
+        // Test invalid `begin == 0` results in an empty srcset string.
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, 0, 100);
+        String expected = "";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCreateSrcSetInvalidBeginAndEnd() {
+        // Test invalid `begin > end` results in an empty srcset string.
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        String actual = ub.createSrcSet("image.png", params, 101, 100);
+        String expected = "";
+
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
The purpose of this PR is to validate "srcset ranges." A srcset
"range" is defined by it's `begin`, `end`, and `tol`.

If `tol` is less than `0.01` (one percent) then it is **invalid**.

If `begin > end`, then `begin` is **invalid**.

No restrictions have been explicitly applied to `end`; this is to
allow for flexibility when the maximum `end` is greater than 8192.

This PR also seeks to establish validation/error semantics for srcsets.
The question to be answered here in review is:

**Is this a sensible way of handling invalid input?**

Doing things this way means we do not have to throw exceptions. The
rationale is this:

- alert callers to an error state without affecting global process state

For instance, it seems likely that callers would rather deal with missing
images and empty srcset strings than with an exception that crashes
an app.

In short, an empty string means our code doesn't "pretend" things are
okay while failing gracefully within a larger application.

**Update**:
After some discussion, we have chosen to `throw` exceptions in these
exceptional cases. I am closing this PR and reopening another that
reflects this decision.