### PR TITLE
feat: throw when validator detects invalid input

### DIFF
--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -197,6 +197,9 @@ public class URLBuilder {
     }
 
     private String createSrcSetPairs(String path, Map<String, String> params, Integer[] widths) {
+        // Validate
+        Validator.validateWidths(widths);
+
         StringBuilder srcset = new StringBuilder();
 
         for (Integer width: widths) {
@@ -252,6 +255,7 @@ public class URLBuilder {
      * @return array list of image width values
      */
     public static ArrayList<Integer> targetWidths(int begin, int end, double tol) {
+        Validator.validateMinMaxTol(begin, end, tol);
         return computeTargetWidths(begin, end, tol);
     }
 

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -197,7 +197,6 @@ public class URLBuilder {
     }
 
     private String createSrcSetPairs(String path, Map<String, String> params, Integer[] widths) {
-        // Validate
         Validator.validateWidths(widths);
 
         StringBuilder srcset = new StringBuilder();

--- a/src/main/java/com/imgix/Validator.java
+++ b/src/main/java/com/imgix/Validator.java
@@ -1,0 +1,102 @@
+package com.imgix;
+
+public class Validator {
+    private static final double ONE_PERCENT = 0.01;
+
+    /**
+     * Validate `begin` width value is at least zero.
+     *
+     * @param begin Beginning width value of a width-range.
+     * @throws RuntimeException If `begin` is less than zero.
+     */
+    public static void validateMinWidth(int begin) throws RuntimeException {
+        if (begin < 0) {
+            throw new RuntimeException("`begin` width value must be greater than zero");
+        }
+    }
+
+    /**
+     * Validate `end` width value is at least zero.
+     *
+     * @param end Ending width value of a width-range.
+     * @throws RuntimeException If `end` is less than zero.
+     */
+    public static void validateMaxWidth(int end) throws RuntimeException {
+        if (end < 0) {
+            throw new RuntimeException("`end` width value must be greater than zero"); 
+        }
+    }
+
+    /**
+     * Validate `begin` and `end` represent a valid width-range.
+     *
+     * This validator is the composition of `validateMinWidth` and
+     * `validateMaxWidth`. It also adds a final constraint that
+     * `begin` be less than or equal to `end`.
+     *
+     * @param begin Beginning width value of a width-range.
+     * @param end Ending width value of a width-range.
+     * @throws RuntimeException If a width range `begin`s after it `end`s.
+     */
+    public static void validateRange(int begin, int end) throws RuntimeException {
+        // Validate the minimum width, `begin`.
+        validateMinWidth(begin);
+        // Validate the maximum width, `end`.
+        validateMaxWidth(end);
+
+        // Ensure that the range is valid, ie. `begin <= end`.
+        if (end < begin) {
+            throw new RuntimeException("`begin` width value must be less than `end` width value"); 
+        }
+    }
+
+    /**
+     * Validate `tol`erance is at least `ONE_PERCENT`.
+     *
+     * @param tol Tolerable amount of image width variation.
+     * @throws RuntimeException If `tol` is less than `ONE_PERCENT`.
+     */
+    public static void validateTolerance(double tol) throws RuntimeException {
+        String msg = "`tol`erance value must be greater than," +
+            "or equal to one percent, ie. >= 0.01";
+
+        if (tol < ONE_PERCENT) {
+            throw new RuntimeException(msg);
+        }
+    }
+
+    /**
+     * Validate that `begin`, `end`, and `tol` represent a valid srcset range.
+     *
+     * @param begin Beginning width value of a width-range.
+     * @param end Ending width value of a width-range.
+     * @param tol Tolerable amount of image width variation.
+     * @throws RuntimeException
+     */
+    public static void validateMinMaxTol(int begin, int end, double tol) throws RuntimeException {
+        validateRange(begin, end);
+        validateTolerance(tol);
+    }
+
+    /**
+     * Validate `widths` array contains only positive values.
+     *
+     * @param widths Integer array of positive image width values.
+     * @throws RuntimeException If `widths` contains a negative value.
+     */
+    public static void validateWidths(Integer[] widths) throws RuntimeException {
+        if (widths == null) {
+            throw new RuntimeException("`widths` array cannot be `null`");
+        }
+
+        if (widths.length == 0) {
+            throw new RuntimeException("`widths` array cannot be empty");
+        }
+
+        for (Integer w: widths) {
+            if (w < 0) {
+                throw new RuntimeException("width values in `widths` cannot be negative");
+            }
+        }
+    }
+}

--- a/src/main/java/com/imgix/Validator.java
+++ b/src/main/java/com/imgix/Validator.java
@@ -57,7 +57,7 @@ public class Validator {
      * @throws RuntimeException If `tol` is less than `ONE_PERCENT`.
      */
     public static void validateTolerance(double tol) throws RuntimeException {
-        String msg = "`tol`erance value must be greater than," +
+        String msg = "`tol`erance value must be greater than, " +
             "or equal to one percent, ie. >= 0.01";
 
         if (tol < ONE_PERCENT) {

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -704,4 +704,25 @@ public class TestSrcSet {
 
         assertEquals(expected, actual);
     }
+
+    @Test(expected = RuntimeException.class)
+    public void testCreateSrcSetInvalidWidths() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        ub.createSrcSet("image.png", params, new Integer[] {100, 200, 300, 400, 500, -600});
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testCreateSrcSetInvalidRange() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        ub.createSrcSet("image.png", params, 100, 99);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testCreateSrcSetInvalidTol() {
+        URLBuilder ub = new URLBuilder("test.imgix.net", false, "", false);
+        HashMap<String, String>  params = new HashMap<String, String>();
+        ub.createSrcSet("image.png", params, 0.001);
+    }
 }

--- a/src/test/java/com/imgix/test/TestValidator.java
+++ b/src/test/java/com/imgix/test/TestValidator.java
@@ -1,0 +1,76 @@
+package com.imgix.test;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.imgix.Validator;
+
+@RunWith(JUnit4.class)
+public class TestValidator {
+    private static final int LESS_THAN_ZERO = -1;
+    /**
+     * Test `validateMinWidth` throws if passed a value less than
+     * zero.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testValidateMinWidth() {
+        Validator.validateMinWidth(LESS_THAN_ZERO);
+    }
+
+    /**
+     * Test `validateMaxWidth` throws if passed a value less than
+     * zero.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testValidateMaxWidth() {
+        Validator.validateMaxWidth(LESS_THAN_ZERO);
+    }
+
+    /**
+     * Test `validateRange` throws if passed an invalid range,
+     * ie. if `BEGIN > END`.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testValidateRange() {
+        final int BEGIN = 100;
+        final int END = 99;
+        Validator.validateRange(BEGIN, END);
+    }
+
+    /**
+     * Test `validateTolerance` throws if passed a `tol`erance
+     * that is less than one percent.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testValidateTolerance() {
+        final double LESS_THAN_ONE_PERCENT = 0.001;
+        Validator.validateTolerance(LESS_THAN_ONE_PERCENT);
+    }
+
+    /**
+     * Test `validateWidths` throws if a negative width value
+     * has been found.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testValidateWidths() {
+        Integer[] widths = new Integer[] {100, 200, 300, -400};
+        Validator.validateWidths(widths);
+    }
+
+    /**
+     * Test `validateWidths` throws if passed a `null` array.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testValidateWidthsNullArray() {
+        Validator.validateWidths(null);
+    }
+
+    /**
+     * Test `validateWidths` throws if passed an empty array.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testValidateWidthsEmptyArray() {
+        Validator.validateWidths(new Integer[] {});
+    }
+}


### PR DESCRIPTION
This PR implements basic validation for `begin`, `end`, `tol`, and
`widths`.

**When invalid input is encountered an exception will be thrown.**

Specifically, a `RuntimeException` is thrown detailing the error
state that has occurred.

We debated whether or not to throw exceptions in a few cases;
ultimately we have decided that error states should be clearly
defined and handled (both for us internally and for users).

What this means is that, in a few cases, our library will `throw`
which results in callers being immediately alerted of the error
state that caused the exception to be thrown (so that errors are
not propagated silently throughout application code).

This is an added layer of _safety_ to help ensure code that depends
on this library remains correct (w.r.t. it's usage of this library).

In short, the validation we are doing here says that callers:
- cannot define negative image widths
- cannot define invalid width ranges, e.g. `begin > end`
- cannot define invalid width `tol`erance values, e.g. `0.00001`

We consider these constraints to be reasonable and **empowering**
rather than _limiting_. That is, this kind of validation helps guard
against typos, e.g.

This call to `createSrcSet`
```java
builder.createSrcSet("image.png", params, 400, 100)
```
Where the function signature is:
```java
createSrcSet(String path, Map<String, String> params, int begin, int end) {...}
```
Will result in this exception, message, and trace:
```java
`begin` width value must be less than `end` width value
java.lang.RuntimeException: `begin` width value must be less than `end` width value
	at com.imgix.Validator.validateRange(Validator.java:49)
	at com.imgix.Validator.validateMinMaxTol(Validator.java:77)
	at com.imgix.URLBuilder.targetWidths(URLBuilder.java:258)
```