### PR TITLE
fix(gradle-build): include maven plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.jfrog.bintray" version "1.7"
     id 'java'
+    id 'maven'
     id 'maven-publish'
 }
 


### PR DESCRIPTION
This PR includes (adds) the maven plugin. This plugin is currently
deprecated:

```text
Deprecated Gradle features were used in this build, making it
incompatible with Gradle 7.0.

Use '--warning-mode all' to show the individual deprecation
warnings.
```

```text
The maven plugin has been deprecated. This is scheduled to be removed
in Gradle 7.0. Please use the maven-publish plugin instead. Consult
the [upgrading guide for further information](https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#legacy_publication_system_is_deprecated_and_replaced_with_the_publish_plugins)
```

A more helpful link might be [this one here](https://docs.gradle.org/6.3/userguide/publishing_maven.html#sec:modifying_the_generated_pom).

For now, we are including `maven` alongside `maven-publish` as
`maven-publish` alone doesn't make a successful upload. Switching
to the new plugin will require a little bit of time, wading through docs,
so for now we will the deprecated feature while we research the new
publishing system.