### PR TITLE
fix: create dpr srcset when only h passed in as param

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ version = '2.3.0'
 
 description = """Imgix Java Client"""
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 11
+targetCompatibility = 11
 
 repositories {
     maven { url "https://repo.maven.apache.org/maven2" }
@@ -38,11 +38,14 @@ bintray {
   }
 }
 
+
+// `classifier = 'sources'` is a deprecated feature--removed!
 task sourcesJar(type: Jar, dependsOn: classes) {
     archiveClassifier.set("sources")
     from sourceSets.main.allSource
 }
 
+// `classifier = 'javadoc'` is a deprecated feature--removed!
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier.set("javadoc")
     from javadoc.destinationDir

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ version = '2.3.0'
 
 description = """Imgix Java Client"""
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
 
 repositories {
     maven { url "https://repo.maven.apache.org/maven2" }

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -90,8 +90,7 @@ public class URLBuilder {
      *
      * This function creates a dpr based srcset if `params`
      * contain either:
-     * - a width "w" param, _or_
-     * - a height "h" and aspect ratio "ar" params
+     * - a width "w" param _or_ a height "h" param.
      *
      * Otherwise, a srcset of width-pairs is created.
      *

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -312,10 +312,10 @@ public class URLBuilder {
         String aspectRatio = params.get("ar");
         boolean hasAspectRatio = (aspectRatio != null) && !aspectRatio.isEmpty();
 
-        // If `params` have a width param or _both_ height and aspect
-        // ratio parameters then the srcset to be constructed with
-        // these params _is dpr based_.
-        return hasWidth || (hasHeight && hasAspectRatio);
+        // If `params` have a width param or height parameters
+        // then the srcset to be constructed with these params
+        // _is dpr based_.
+        return hasWidth || hasHeight;
     }
 
     private static boolean notCustom(double begin, double end, double tol) {

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -13,6 +13,8 @@ import com.imgix.URLBuilder;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
+
+
 @RunWith(JUnit4.class)
 public class TestSrcSet {
 
@@ -22,12 +24,13 @@ public class TestSrcSet {
     private static String[] srcsetHeightSplit;
     private static String[] srcsetAspectRatioSplit;
     private static String[] srcsetWidthAndHeightSplit;
+    private static String srcsetHeight;
     private static String[] srcsetWidthAndAspectRatioSplit;
     private static String[] srcsetHeightAndAspectRatioSplit;
 
     @BeforeClass
     public static void buildAllSrcSets() {
-        String srcset, srcsetWidth, srcsetHeight, srcsetAspectRatio, srcsetWidthAndHeight, srcsetWidthAndAspectRatio, srcsetHeightAndAspectRatio;
+        String srcset, srcsetWidth, srcsetAspectRatio, srcsetWidthAndHeight, srcsetWidthAndAspectRatio, srcsetHeightAndAspectRatio;
 
         URLBuilder ub = new URLBuilder("test.imgix.net", true, "MYT0KEN" , false);
         params = new HashMap<String, String>();
@@ -210,22 +213,32 @@ public class TestSrcSet {
     }
 
     @Test
-    public void testHeightGeneratesCorrectWidths() {
-        int[] targetWidths = {100, 116, 135, 156, 181, 210, 244, 283,
-                328, 380, 441, 512, 594, 689, 799, 927,
-                1075, 1247, 1446, 1678, 1946, 2257, 2619,
-                3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192};
+    public void testGivenHeightSRCSETGeneratePairs() {
+        assertEquals(srcsetHeightSplit.length, 5);
+    }
 
-        String generatedWidth;
-        int index = 0;
-        int widthInt;
+    @Test
 
-        for (String src: srcsetHeightSplit) {
-            generatedWidth = src.split(" ")[1];
-            widthInt = Integer.parseInt(generatedWidth.substring(0,generatedWidth.length()-1));
-            assertEquals(targetWidths[index], widthInt);
-            index++;
+    public void testHeightBasedSrcsetHasDprValues() {
+        String[] split_srcset = srcsetHeightSplit;
+        String[] descriptors =  new String[srcsetHeightSplit.length];
+
+        // extract descriptors
+        for (int i = 0; i < split_srcset.length; i++) {
+            String val =  split_srcset[i];
+            String empty_str="";
+            String space=" ";
+            String comma=",";
+            // Split on space
+            String[] split_url = val.split(space);
+            if (split_url.length == 2) {
+                // #Remember to remove the commas.
+                String sub_str = split_url[1];
+                descriptors[i] = sub_str.replace(comma, empty_str);
+            }
         }
+
+        assertEquals(Arrays.toString(descriptors), "[1x, 2x, 3x, 4x, 5x]");
     }
 
     @Test
@@ -240,40 +253,8 @@ public class TestSrcSet {
 
     @Test
     public void testHeightReturnsExpectedNumberOfPairs() {
-        int expectedPairs = 31;
+        int expectedPairs = 5;
         assertEquals(expectedPairs, srcsetHeightSplit.length);
-    }
-
-    @Test
-    public void testHeightDoesNotExceedBounds() {
-        String minWidth = srcsetHeightSplit[0].split(" ")[1];
-        String maxWidth = srcsetHeightSplit[srcsetHeightSplit.length-1].split(" ")[1];
-
-        int minWidthInt = Integer.parseInt(minWidth.substring(0,minWidth.length()-1));
-        int maxWidthInt = Integer.parseInt(maxWidth.substring(0,maxWidth.length()-1));
-
-        assert(minWidthInt >= 100);
-        assert(maxWidthInt <= 8192);
-    }
-
-    // a 17% testing threshold is used to account for rounding
-    @Test
-    public void testHeightDoesNotIncreaseMoreThan17Percent() {
-        final double INCREMENT_ALLOWED = .17;
-        String width;
-        int widthInt, prev;
-
-        // convert and store first width (typically: 100)
-        width = srcsetHeightSplit[0].split(" ")[1];
-        prev = Integer.parseInt(width.substring(0,width.length()-1));
-
-        for (String src : srcsetHeightSplit) {
-            width = src.split(" ")[1];
-            widthInt = Integer.parseInt(width.substring(0,width.length()-1));
-
-            assert((widthInt / prev) < (1 + INCREMENT_ALLOWED));
-            prev = widthInt;
-        }
     }
 
     @Test

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -24,13 +24,12 @@ public class TestSrcSet {
     private static String[] srcsetHeightSplit;
     private static String[] srcsetAspectRatioSplit;
     private static String[] srcsetWidthAndHeightSplit;
-    private static String srcsetHeight;
     private static String[] srcsetWidthAndAspectRatioSplit;
     private static String[] srcsetHeightAndAspectRatioSplit;
 
     @BeforeClass
     public static void buildAllSrcSets() {
-        String srcset, srcsetWidth, srcsetAspectRatio, srcsetWidthAndHeight, srcsetWidthAndAspectRatio, srcsetHeightAndAspectRatio;
+        String srcset, srcsetWidth, srcsetHeight, srcsetAspectRatio, srcsetWidthAndHeight, srcsetWidthAndAspectRatio, srcsetHeightAndAspectRatio;
 
         URLBuilder ub = new URLBuilder("test.imgix.net", true, "MYT0KEN" , false);
         params = new HashMap<String, String>();

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -218,27 +218,16 @@ public class TestSrcSet {
     }
 
     @Test
-
     public void testHeightBasedSrcsetHasDprValues() {
-        String[] split_srcset = srcsetHeightSplit;
-        String[] descriptors =  new String[srcsetHeightSplit.length];
+        String generatedRatio;
+        int expectedRatio = 1;
+        assert(srcsetHeightSplit.length == 5);
 
-        // extract descriptors
-        for (int i = 0; i < split_srcset.length; i++) {
-            String val =  split_srcset[i];
-            String empty_str="";
-            String space=" ";
-            String comma=",";
-            // Split on space
-            String[] split_url = val.split(space);
-            if (split_url.length == 2) {
-                // #Remember to remove the commas.
-                String sub_str = split_url[1];
-                descriptors[i] = sub_str.replace(comma, empty_str);
-            }
+        for (String src: srcsetHeightSplit) {
+            generatedRatio = src.split(" ")[1];
+            assertEquals(expectedRatio + "x", generatedRatio);
+            expectedRatio++;
         }
-
-        assertEquals(Arrays.toString(descriptors), "[1x, 2x, 3x, 4x, 5x]");
     }
 
     @Test

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -236,7 +236,7 @@ public class TestSrcSet {
 
         for (String src: srcsetHeightSplit) {
             url = src.split(" ")[0];
-            assert(url.contains("h="));
+            assert(url.contains("h=300"));
         }
     }
 

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -217,6 +217,16 @@ public class TestSrcSet {
     }
 
     @Test
+    public void testHeightIncludesDPRParam() {
+        String src;
+
+        for (int i = 0; i < srcsetHeightSplit.length; i++) {
+            src = srcsetHeightSplit[i].split(" ")[0];
+            assert(src.contains(String.format("dpr=%s", i+1)));
+        }
+    }
+
+    @Test
     public void testHeightBasedSrcsetHasDprValues() {
         String generatedRatio;
         int expectedRatio = 1;


### PR DESCRIPTION
# Description

This PR ensures a DPR-based SrcSet is generated when a fixed height is the only parameter value. 

- It removes tests that no longer apply to only having `h` as a param, and
- adds tests that ensure the DPR `sercset` was generated correctly.

# Up for discussion

This PR also introduces some build changes that were necessary to bring the Java comparability up to speed with MacOs BigSur development.