### PR TITLE
chore: transition to maven central for deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
 language: java
 jdk:
 - openjdk11
+- openjdk8
 script:
 - ./gradlew test
 - ./gradlew testUTF32

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
 language: java
 jdk:
 - openjdk11
-- openjdk8
 script:
 - ./gradlew test
 - ./gradlew testUTF32

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 `imgix-java` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
 
 [![Download](https://api.bintray.com/packages/imgix/maven/imgix-java/images/download.svg) ](https://bintray.com/imgix/maven/imgix-java/_latestVersion)
+[![Maven Central](https://img.shields.io/maven-central/v/com.imgix/imgix-java.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.imgix%22%20AND%20a:%22imgix-java%22)
 [![Build Status](https://travis-ci.com/imgix/imgix-java.svg?branch=main)](https://travis-ci.com/imgix/imgix-java)
 [![License](https://img.shields.io/github/license/imgix/imgix-java)](https://github.com/imgix/imgix-java/blob/main/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fimgix%2Fimgix-java.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fimgix%2Fimgix-java?ref=badge_shield)

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ group = 'com.imgix' // sonatype groupId
 version = '2.3.0' // add SNAPSHOT if deploying to staging
 
 // declare expected JDK versions
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 8
+targetCompatibility = 8
 
 // Delcare the maven repo ans the source for the junit and hamcrest repository and dependencies
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@ plugins {
   id 'maven-publish'
   id 'signing'
   id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
+  id "io.freefair.maven-central.validate-poms" version "5.3.0"
 }
 
 group = 'com.imgix' // sonatype groupId
-version = '2.3.0' // add SNAPSHOT if deploying to staging
+version = '2.3.0-SNAPSHOT' // add SNAPSHOT if deploying to staging repo
 
 // declare expected JDK versions
 sourceCompatibility = 8
@@ -39,7 +40,7 @@ publishing {
     release(MavenPublication) {
       groupId "com.imgix" // sonatype JIRA groupId
       artifactId "imgix-java" // the name of the library
-      version "2.3.0" // add SNAPSHOT if staging
+      version '2.3.0-SNAPSHOT' // add SNAPSHOT if staging
       from(components["java"]) // this is a dependency of MavenPublication
 
       // provide all the metadata for the library
@@ -84,14 +85,31 @@ signing {
   sign publishing.publications
 }
 
-// plugin assumes ossrhUsername, ossrhPassword present in either env or gradle.properties
+
+// validate the pom.xml has all the attributes required by MacenCentral
+task validateMavenPom(type: io.freefair.gradle.plugins.maven.central.ValidateMavenPom) {
+    System.out.println("validating pom.xml...")
+    pomFile = file("build/publications/release/pom-default.xml")
+    ignoreFailures = false
+    dependsOn('publishToSonatype')
+}
+
 nexusPublishing {
+    // assumes sonatype credentials present in either env or gradle.properties
     def sonatypeUsername = findProperty("sonatypeUsername")
     def sonatypePassword = findProperty("sonatypePassword")
     repositories {
         sonatype {
           username = sonatypeUsername
           password = sonatypePassword
+          useStaging = true // force all deploys to use staging repos
         }
+    }
+    // sets timout & retry options to avoid hangups when nexus API is acting up
+    clientTimeout = Duration.ofSeconds(300)
+    connectTimeout = Duration.ofSeconds(60)
+    transitionCheckOptions {
+        maxRetries.set(40)
+        delayBetween.set(java.time.Duration.ofMillis(3000))
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,11 @@ plugins {
     id 'maven'
     id 'maven-publish'
     id 'signing'
-
 }
 
-group = 'com.imgix'
+group = 'com.imgix' // sonatype groupId
 version = '2.3.0'
-archivesBaseName = "Imgix Java Client"
+archivesBaseName = "imgix-java"
 
 sourceCompatibility = 11
 targetCompatibility = 11
@@ -57,16 +56,16 @@ uploadArchives {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }
 
-            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }
 
             pom.project {
-                name 'Imgix Java Client'
+                name 'imgix-java'
                 packaging 'jar'
                 // optionally artifactId can be defined here
                 description 'imgix-java is a client library for generating image URLs with imgix.'

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,19 @@ plugins {
 group = 'com.imgix' // sonatype groupId
 version = '2.3.0' // add SNAPSHOT if deploying to staging
 
+// declare expected JDK versions
 sourceCompatibility = 11
 targetCompatibility = 11
+
+// Delcare the maven repo ans the source for the junit and hamcrest repository and dependencies
+repositories {
+    maven { url "https://repo.maven.apache.org/maven2" }
+}
+
+dependencies {
+    testImplementation group: 'junit', name: 'junit', version:'4.12'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'
+}
 
 java {
     // A task that packages the output of the javadoc task in JAR with classifier javadoc.
@@ -62,18 +73,6 @@ publishing {
       }
     }
   }
-  // TODO(luis): remove reposiories field, it's not needed when using nexusPublishing
-  repositories {
-    maven {
-      name = "sonatype"
-      url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-  
-      credentials {
-        username ossrhUsername
-        password ossrhPassword
-      }
-    }
-  }
 }
 
 // sign all the files with the local gpg key, key must have been previously deployed online
@@ -87,7 +86,12 @@ signing {
 
 // plugin assumes ossrhUsername, ossrhPassword present in either env or gradle.properties
 nexusPublishing {
+    def sonatypeUsername = findProperty("sonatypeUsername")
+    def sonatypePassword = findProperty("sonatypePassword")
     repositories {
-        sonatype()
+        sonatype {
+          username = sonatypeUsername
+          password = sonatypePassword
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,53 +1,35 @@
 plugins {
-    id "com.jfrog.bintray" version "1.7"
     id 'java'
     id 'maven'
     id 'maven-publish'
+    id 'signing'
+
 }
 
 group = 'com.imgix'
 version = '2.3.0'
+archivesBaseName = "Imgix Java Client"
 
-description = """Imgix Java Client"""
-
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 11
+targetCompatibility = 11
 
 repositories {
     maven { url "https://repo.maven.apache.org/maven2" }
 }
 
+// This is new, this prepares the project for Gradle 7.0 (currently on 6.3)
 dependencies {
     testImplementation group: 'junit', name: 'junit', version:'4.12'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'
 }
 
-bintray {
-  user = System.getenv('BINTRAY_USER')
-  key = System.getenv('BINTRAY_KEY')
-  pkg {
-    userOrg = 'imgix'
-    repo = 'maven'
-    name = 'imgix-java'
-    licenses = ['BSD 2-Clause']
-    vcsUrl = 'https://github.com/imgix/imgix-java.git'
-    version {
-      name = '2.3.0'
-    }
-    configurations = ['archives']
-  }
-}
-
-
 // `classifier = 'sources'` is a deprecated feature--removed!
 task sourcesJar(type: Jar, dependsOn: classes) {
-    archiveClassifier.set("sources")
     from sourceSets.main.allSource
 }
 
 // `classifier = 'javadoc'` is a deprecated feature--removed!
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    archiveClassifier.set("javadoc")
     from javadoc.destinationDir
 }
 
@@ -56,6 +38,61 @@ task testUTF32(type: Test) {
 }
 
 artifacts {
-    archives sourcesJar
-    archives javadocJar
+    archives sourcesJar, javadocJar
+}
+
+signing {
+    if (project.hasProperty('signing.keyId') &&
+        project.hasProperty('signing.password') &&
+        project.hasProperty('signing.secretKeyRingFile')) {
+        sign configurations.archives
+
+        /* Uncomment this if you use shadow in your build process */
+        // sign configurations.shadow
+    }
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            pom.project {
+                name 'Imgix Java Client'
+                packaging 'jar'
+                // optionally artifactId can be defined here
+                description 'imgix-java is a client library for generating image URLs with imgix.'
+                url 'https://github.com/imgix/imgix-java'
+
+                scm {
+                    connection 'https://github.com/imgix/imgix-java.git'
+                    developerConnection 'https://github.com/imgix/imgix-java.git'
+                    url 'https://github.com/imgix/imgix-java'
+                }
+
+                licenses {
+                    license {
+                        name 'BSD-2-Clause License'
+                        url 'https://github.com/imgix/imgix-java/blob/main/LICENSE'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'imgix'
+                        name 'imgix'
+                        email 'sdk@imgix.com'
+                    }
+                }
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,97 +1,89 @@
 plugins {
-    id 'java'
-    id 'maven'
-    id 'maven-publish'
-    id 'signing'
+  id 'java'
+  id 'maven-publish'
+  id 'signing'
+  id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 }
 
 group = 'com.imgix' // sonatype groupId
-version = '2.3.0'
-archivesBaseName = "imgix-java"
+version = '2.3.0' // add SNAPSHOT if deploying to staging
 
 sourceCompatibility = 11
 targetCompatibility = 11
 
-repositories {
-    maven { url "https://repo.maven.apache.org/maven2" }
+java {
+    // A task that packages the output of the javadoc task in JAR with classifier javadoc.
+    withJavadocJar()
+    // A task that packages the Java sources of the main SourceSet in JAR with classifier sources.
+    withSourcesJar()
 }
 
-// This is new, this prepares the project for Gradle 7.0 (currently on 6.3)
-dependencies {
-    testImplementation group: 'junit', name: 'junit', version:'4.12'
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'
-}
-
-// `classifier = 'sources'` is a deprecated feature--removed!
-task sourcesJar(type: Jar, dependsOn: classes) {
-    from sourceSets.main.allSource
-}
-
-// `classifier = 'javadoc'` is a deprecated feature--removed!
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    from javadoc.destinationDir
-}
-
+// TODO(sherwin): add comments explaining why this was necessary
 task testUTF32(type: Test) {
-    jvmArgs "-Dfile.encoding=UTF-32"
+  jvmArgs "-Dfile.encoding=UTF-32"
 }
 
-artifacts {
-    archives sourcesJar, javadocJar
-}
+publishing {
+  publications {
+    release(MavenPublication) {
+      groupId "com.imgix" // sonatype JIRA groupId
+      artifactId "imgix-java" // the name of the library
+      version "2.3.0" // add SNAPSHOT if staging
+      from(components["java"]) // this is a dependency of MavenPublication
 
-signing {
-    if (project.hasProperty('signing.keyId') &&
-        project.hasProperty('signing.password') &&
-        project.hasProperty('signing.secretKeyRingFile')) {
-        sign configurations.archives
+      // provide all the metadata for the library
+      pom {
+        artifactId = "imgix-java"
+        name = 'imgix-java'
+        packaging = 'jar'
+        description = 'imgix-java is a client library for generating image URLs with imgix.'
+        url = 'https://github.com/imgix/imgix-java'
 
-        /* Uncomment this if you use shadow in your build process */
-        // sign configurations.shadow
-    }
-}
-
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-
-            pom.project {
-                name 'imgix-java'
-                packaging 'jar'
-                // optionally artifactId can be defined here
-                description 'imgix-java is a client library for generating image URLs with imgix.'
-                url 'https://github.com/imgix/imgix-java'
-
-                scm {
-                    connection 'https://github.com/imgix/imgix-java.git'
-                    developerConnection 'https://github.com/imgix/imgix-java.git'
-                    url 'https://github.com/imgix/imgix-java'
-                }
-
-                licenses {
-                    license {
-                        name 'BSD-2-Clause License'
-                        url 'https://github.com/imgix/imgix-java/blob/main/LICENSE'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id 'imgix'
-                        name 'imgix'
-                        email 'sdk@imgix.com'
-                    }
-                }
-            }
+        scm {
+          connection = 'https://github.com/imgix/imgix-java.git'
+          developerConnection = 'https://github.com/imgix/imgix-java.git'
+          url = 'https://github.com/imgix/imgix-java'
         }
+
+        licenses {
+          license {
+            name = 'BSD-2-Clause License'
+            url = 'https://github.com/imgix/imgix-java/blob/main/LICENSE'
+          }
+        }
+
+        developers {
+          developer {
+            id = 'imgix'
+            name = 'imgix'
+            email = 'sdk@imgix.com'
+          }
+        }
+      }
+    }
+  }
+  // TODO(luis): remove reposiories field, it's not needed when using nexusPublishing
+  repositories {
+    maven {
+      name = "sonatype"
+      url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+  
+      credentials {
+        username ossrhUsername
+        password ossrhPassword
+      }
+    }
+  }
+}
+
+// sign all the files with the local gpg key, key must have been previously deployed online
+signing {
+    sign publishing.publications
+}
+
+// plugin assumes ossrhUsername, ossrhPassword present in either env or gradle.properties
+nexusPublishing {
+    repositories {
+        sonatype()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,9 @@ java {
     withSourcesJar()
 }
 
-// TODO(sherwin): add comments explaining why this was necessary
+// A task that runs tests with a non-UTF-8 encoding scheme.
+// This ensures that the library behavior does not change
+// even when the default charset of the calling system does.
 task testUTF32(type: Test) {
   jvmArgs "-Dfile.encoding=UTF-32"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,11 @@ publishing {
 
 // sign all the files with the local gpg key, key must have been previously deployed online
 signing {
-    sign publishing.publications
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+  sign publishing.publications
 }
 
 // plugin assumes ossrhUsername, ossrhPassword present in either env or gradle.properties


### PR DESCRIPTION
## Description
This PR introduces `gradle.build` changes that should allow us to transition to publishing our library on the maven central repository.

- uses [nexus-publish-plugin](https://github.com/gradle-nexus/publish-plugin) to manage sonatype deployment needs
- uses [io.freefair.maven-central.validate-poms](https://plugins.gradle.org/plugin/io.freefair.maven-central.validate-poms) to validate generated `pom.xml` file matches MavenCentral specs
- assumes certain environment variables are already set