### PR TITLE
chore(release): version 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+### Version 2.3.1 (_March 24, 2021_)
+* docs: add maven badge to README.md ([#65](https://github.com/imgix/imgix-java/pull/65))
+* docs: update fixed-widths section ([#63](https://github.com/imgix/imgix-java/pull/63))
+* fix: create dpr srcset when only h passed in as param ([#62](https://github.com/imgix/imgix-java/pull/62))
+* docs: update travis badge to travis-ci.com ([#60](https://github.com/imgix/imgix-java/pull/60))
+* fix(gradle-build): include maven plugin ([#55](https://github.com/imgix/imgix-java/pull/55))
+* docs(readme): correct percentage typos ([#53](https://github.com/imgix/imgix-java/pull/53))
+
 ### Version 2.3.0 (_June 05, 2020_)
 * feat: custom srcsets ([#44](https://github.com/imgix/imgix-java/pull/44))
 * fix: convert tol to float ([#49](https://github.com/imgix/imgix-java/pull/49))

--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ To add Imgix-Java to your project, include the following in your project's build
 
 ```
 dependencies {
-   compile "com.imgix:imgix-java:2.3.0"
+   compile "com.imgix:imgix-java:2.3.1"
 }
 ```
 
-And if this is your first external JCenter dependency you'll need to add, again to your project level build.gradle, the following:
+And if this is your first external MavenCentral dependency you'll need to add, again to your project level build.gradle, the following:
 
 ```
 buildscript {
    repositories {
-      jcenter()
+        mavenCentral()
    }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.imgix' // sonatype groupId
-version = '2.3.0-SNAPSHOT' // add SNAPSHOT if deploying to staging repo
+version = '2.3.1' // add SNAPSHOT if deploying to staging repo
 
 // declare expected JDK versions
 sourceCompatibility = 8
@@ -42,7 +42,7 @@ publishing {
     release(MavenPublication) {
       groupId "com.imgix" // sonatype JIRA groupId
       artifactId "imgix-java" // the name of the library
-      version '2.3.0-SNAPSHOT' // add SNAPSHOT if staging
+      version '2.3.1' // add SNAPSHOT if staging
       from(components["java"]) // this is a dependency of MavenPublication
 
       // provide all the metadata for the library

--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 public class URLBuilder {
 
-    public static final String VERSION = "2.3.0";
+    public static final String VERSION = "2.3.1";
     private static final String DOMAIN_REGEX = "^(?:[a-z\\d\\-_]{1,62}\\.){0,125}(?:[a-z\\d](?:\\-(?=\\-*[a-z\\d])|[a-z]|\\d){0,62}\\.)[a-z\\d]{1,63}$";
 
     private String domain;


### PR DESCRIPTION
# Description
 
This PR updates the changelog.md and readme.md to reflect the version bump to 2.3.1. It also removes references to JCenter.