### PR TITLE
fix(URLHelper): correctly encode more special chars

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
   "editor.tabSize": 2,
   "editor.formatOnType": true,
   "google-java-format.executable": "/usr/local/bin/google-java-format",
-  "editor.formatOnPaste": false,
-  "editor.formatOnSave": false,
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true,
   "[java]": {
     "editor.defaultFormatter": "ilkka.google-java-format",
   }

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -1,7 +1,6 @@
 package com.imgix;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -178,35 +177,16 @@ public class URLHelper {
   }
 
   public static String encodeURI(String s) {
-    String result =
-        s.replaceAll("\\+", "%2B")
-            .replaceAll("\\:", "%3A")
-            .replaceAll("\\?", "%3F")
-            .replaceAll("\\#", "%23")
-            .replaceAll(" ", "%20")
-            .replaceAll("\\%21", "!")
-            .replaceAll("\\%27", "'")
-            .replaceAll("\\%28", "(")
-            .replaceAll("\\%29", ")")
-            .replaceAll("\\%7E", "~");
-
-    return result.replace("\\", "");
-  }
-
-  public static String decodeURIComponent(String s) {
-    if (s == null) {
-      return null;
-    }
-
-    String result = null;
-
-    try {
-      result = URLDecoder.decode(s, UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      result = s;
-    }
-
-    return result;
+    return s.replaceAll("\\+", "%2B")
+        .replaceAll("\\:", "%3A")
+        .replaceAll("\\?", "%3F")
+        .replaceAll("\\#", "%23")
+        .replaceAll(" ", "%20")
+        .replaceAll("\\%21", "!")
+        .replaceAll("\\%27", "'")
+        .replaceAll("\\%28", "(")
+        .replaceAll("\\%29", ")")
+        .replaceAll("\\%7E", "~");
   }
 
   public static String sanitizePath(String path) {

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -198,9 +198,6 @@ public class URLHelper {
       // Use encodeURIComponent to ensure *all* characters are handled,
       // since it's being used as a path
       return "/" + URLHelper.encodeURIComponent(path);
-    } else if (path.startsWith("http%3A") || path.startsWith("https%3A")) {
-      // To nothing to the URL being used as path since already encoded
-      return "/" + path;
     } else {
       // Use encodeURI if we think the path is just a path,
       // so it leaves legal characters like '/' and '@' alone

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -23,7 +23,7 @@ public class URLHelper {
   public URLHelper(
       String domain, String path, String scheme, String signKey, Map<String, String> parameters) {
     this.domain = domain;
-    this.path = sanitizePath(path);
+    this.path = path;
     this.scheme = scheme;
     this.signKey = signKey;
     this.parameters = new TreeMap<String, String>(parameters);
@@ -75,6 +75,7 @@ public class URLHelper {
   }
 
   public String getURL() {
+    path = sanitizePath(path);
     List<String> queryPairs = new LinkedList<String>();
 
     for (Entry<String, String> entry : parameters.entrySet()) {

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -24,7 +24,7 @@ public class URLHelper {
   public URLHelper(
       String domain, String path, String scheme, String signKey, Map<String, String> parameters) {
     this.domain = domain;
-    this.path = sanatizePath(path);
+    this.path = sanitizePath(path);
     this.scheme = scheme;
     this.signKey = signKey;
     this.parameters = new TreeMap<String, String>(parameters);
@@ -209,7 +209,7 @@ public class URLHelper {
     return result;
   }
 
-  public static String sanatizePath(String path) {
+  public static String sanitizePath(String path) {
     // Strip leading slash first (we'll re-add after encoding)
     path = path.replaceAll("^/", "");
 

--- a/src/main/java/com/imgix/URLHelper.java
+++ b/src/main/java/com/imgix/URLHelper.java
@@ -198,6 +198,9 @@ public class URLHelper {
       // Use encodeURIComponent to ensure *all* characters are handled,
       // since it's being used as a path
       return "/" + URLHelper.encodeURIComponent(path);
+    } else if (path.startsWith("http%3A") || path.startsWith("https%3A")) {
+      // To nothing to the URL being used as path since already encoded
+      return "/" + path;
     } else {
       // Use encodeURI if we think the path is just a path,
       // so it leaves legal characters like '/' and '@' alone

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -300,18 +300,6 @@ public class TestAll {
     assertEquals("jackangers.imgix.net", extractDomain(url));
   }
 
-  @Test
-  public void testEncodeDecode() {
-    String url = "http://a.abcnews.com/assets/images/navigation/abc-logo.png?r=20";
-    String encodedUrl =
-        "http%3A%2F%2Fa.abcnews.com%2Fassets%2Fimages%2Fnavigation%2Fabc-logo.png%3Fr%3D20";
-
-    assertEquals(URLHelper.encodeURIComponent(url), encodedUrl);
-    assertEquals(URLHelper.decodeURIComponent(encodedUrl), url);
-    assertEquals(
-        URLHelper.encodeURIComponent(URLHelper.decodeURIComponent(encodedUrl)), encodedUrl);
-  }
-
   @RunWith(Parameterized.class)
   public static class TestInvalidDomain {
     @Parameters(name = "'domain with '{0}' throws exception'")

--- a/src/test/java/com/imgix/test/TestAll.java
+++ b/src/test/java/com/imgix/test/TestAll.java
@@ -101,6 +101,31 @@ public class TestAll {
               "http://securejackangers.imgix.net/example/chester.png?w=500"
             },
             {
+              "Relative Path With Unencoded Space",
+              "example/chester 1.png",
+              "http://securejackangers.imgix.net/example/chester%201.png?w=500"
+            },
+            {
+              "Relative Path With Unencoded Plus",
+              "example/chester" + "+1" + ".png",
+              "http://securejackangers.imgix.net/example/chester%2B1.png?w=500"
+            },
+            {
+              "Relative Path With Unencoded Colon",
+              "example/chester" + ":1" + ".png",
+              "http://securejackangers.imgix.net/example/chester%3A1.png?w=500"
+            },
+            {
+              "Relative Path With Unencoded Question Mark",
+              "example/chester" + "?1" + ".png",
+              "http://securejackangers.imgix.net/example/chester%3F1.png?w=500"
+            },
+            {
+              "Relative Path With Unencoded Hash",
+              "example/chester" + "#1" + ".png",
+              "http://securejackangers.imgix.net/example/chester%231.png?w=500"
+            },
+            {
               "Absolute Path With Params",
               "/example/chester.png",
               "http://securejackangers.imgix.net/example/chester.png?w=500"


### PR DESCRIPTION
# Description

This PR adds more test cases for encoding paths in the `URLHelper.java` and fixes an issue where some special characters were not being encoded correctly.

This PR also re-enables `formatOnSave` for VSCode IDE to ensure style rulesets get enforced.