### PR TITLE
fix: createSrcSet no longer mutates params

### DIFF
--- a/src/main/java/com/imgix/URLBuilder.java
+++ b/src/main/java/com/imgix/URLBuilder.java
@@ -201,9 +201,11 @@ public class URLBuilder {
 
     StringBuilder srcset = new StringBuilder();
 
+    Map<String, String> srcsetParams = new HashMap<String, String>(params);
+
     for (Integer width : widths) {
-      params.put("w", width.toString());
-      srcset.append(this.createURL(path, params)).append(" ").append(width).append("w,\n");
+      srcsetParams.put("w", width.toString());
+      srcset.append(this.createURL(path, srcsetParams)).append(" ").append(width).append("w,\n");
     }
 
     return srcset.substring(0, srcset.length() - 2);

--- a/src/test/java/com/imgix/test/TestSrcSet.java
+++ b/src/test/java/com/imgix/test/TestSrcSet.java
@@ -668,6 +668,17 @@ public class TestSrcSet {
 
     assertEquals(expected, actual);
   }
+  
+  @Test
+  public void testUnmutatedSrcSetParams() {
+    String DOMAIN = "test.imgix.net";
+    String PATH = "image.png";
+    URLBuilder defaultClient = new URLBuilder(DOMAIN, true, "", false);
+    HashMap<String, String> nullParameters = new HashMap<String, String>();
+    String actual = defaultClient.createSrcSet(PATH, nullParameters, 100, 500, 0.1);
+    
+    assertTrue(nullParameters.isEmpty());
+  }
 
   @Test
   public void testCreateSrcSetBeginEqualsEnd() {


### PR DESCRIPTION
Fixes a bug where `params` was mutated by the `createSrcSet` function.

# Before
`createSrcSet` directly manipulated `params`, resulting in mutation of `params` after a function call. This could result in unintentional behavior if `params` was shared across multiple function calls.

# After
`createSrcSet` creates a  copy of `params` rather than manipulating it directly. `params` can now be safely reused across functions.

# Notes
Our method of copying `params` functions as a deep copy due how Java implements `String`. If a future developer uses this PR as reference for a similar issue in this library, please note that complications might arise depending on `HashMap`'s key value pairs.